### PR TITLE
Adding OFI plugin for rml. The OFI plugin through libfabric interfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -450,6 +450,8 @@ orte/test/system/pmi_abort
 orte/test/system/opal_hwloc
 orte/test/system/opal_db
 orte/test/system/ulfm
+orte/test/system/ofi_query_test
+orte/test/system/ofi_stress
 
 orte/tools/orte-checkpoint/orte-checkpoint
 orte/tools/orte-checkpoint/orte-checkpoint.1

--- a/orte/include/orte/constants.h
+++ b/orte/include/orte/constants.h
@@ -147,7 +147,8 @@ enum {
     ORTE_ERR_OUT_OF_ORDER_MSG               = (ORTE_ERR_BASE - 55),
     ORTE_ERR_OPEN_CHANNEL_DUPLICATE         = (ORTE_ERR_BASE - 56),
     ORTE_ERR_FORCE_SELECT                   = (ORTE_ERR_BASE - 57),
-    ORTE_ERR_JOB_CANCELLED                  = (ORTE_ERR_BASE - 58)
+    ORTE_ERR_JOB_CANCELLED                  = (ORTE_ERR_BASE - 58),
+    ORTE_ERR_CONDUIT_SEND_FAIL		    = (ORTE_ERR_BASE - 59) 
 };
 
 #define ORTE_ERR_MAX                      (ORTE_ERR_BASE - 100)

--- a/orte/mca/ess/base/ess_base_std_orted.c
+++ b/orte/mca/ess/base/ess_base_std_orted.c
@@ -365,6 +365,24 @@ int orte_ess_base_orted_setup(char **hosts)
     /* obviously, we have "reported" */
     jdata->num_reported = 1;
 
+
+    /* setup the PMIx framework - ensure it skips all non-PMIx components,
+     * but do not override anything we were given */
+    opal_setenv("OMPI_MCA_pmix", "^s1,s2,cray,isolated", false, &environ);
+    if (OPAL_SUCCESS != (ret = mca_base_framework_open(&opal_pmix_base_framework, 0))) {
+        ORTE_ERROR_LOG(ret);
+        error = "orte_pmix_base_open";
+        goto error;
+    }
+
+    if (ORTE_SUCCESS != (ret = opal_pmix_base_select())) {
+        ORTE_ERROR_LOG(ret);
+        error = "opal_pmix_base_select";
+        goto error;
+    }
+    /* set the event base */
+    opal_pmix_base_set_evbase(orte_event_base);
+
     /* Setup the communication infrastructure */
     if (ORTE_SUCCESS != (ret = mca_base_framework_open(&orte_oob_base_framework, 0))) {
         ORTE_ERROR_LOG(ret);
@@ -388,6 +406,13 @@ int orte_ess_base_orted_setup(char **hosts)
     }
     /* add our contact info */
     proc->rml_uri = orte_rml.get_contact_info();
+
+    /* setup the PMIx server */
+    if (ORTE_SUCCESS != (ret = pmix_server_init())) {
+        ORTE_ERROR_LOG(ret);
+        error = "pmix server init";
+        goto error;
+    }
 
     /* select the errmgr */
     if (ORTE_SUCCESS != (ret = orte_errmgr_base_select())) {
@@ -495,29 +520,6 @@ int orte_ess_base_orted_setup(char **hosts)
             error = "orte_plm_init";
             goto error;
         }
-    }
-
-    /* setup the PMIx framework - ensure it skips all non-PMIx components,
-     * but do not override anything we were given */
-    opal_setenv("OMPI_MCA_pmix", "^s1,s2,cray,isolated", false, &environ);
-    if (OPAL_SUCCESS != (ret = mca_base_framework_open(&opal_pmix_base_framework, 0))) {
-        ORTE_ERROR_LOG(ret);
-        error = "orte_pmix_base_open";
-        goto error;
-    }
-    if (ORTE_SUCCESS != (ret = opal_pmix_base_select())) {
-        ORTE_ERROR_LOG(ret);
-        error = "opal_pmix_base_select";
-        goto error;
-    }
-    /* set the event base */
-    opal_pmix_base_set_evbase(orte_event_base);
-    /* setup the PMIx server */
-    if (ORTE_SUCCESS != (ret = pmix_server_init())) {
-        /* the server code already barked, so let's be quiet */
-        ret = ORTE_ERR_SILENT;
-        error = "pmix_server_init";
-        goto error;
     }
 
     /* setup the routed info - the selected routed component

--- a/orte/mca/ess/pmi/ess_pmi_module.c
+++ b/orte/mca/ess/pmi/ess_pmi_module.c
@@ -423,7 +423,7 @@ static int rte_init(void)
      * in the job won't be executing this step, so we would hang
      */
     if (ORTE_PROC_IS_NON_MPI && !orte_do_not_barrier) {
-        opal_pmix.fence(NULL, 0);
+        OPAL_MODEX();
     }
 
     return ORTE_SUCCESS;

--- a/orte/mca/rml/base/base.h
+++ b/orte/mca/rml/base/base.h
@@ -131,6 +131,10 @@ typedef struct {
     union {
         orte_rml_callback_fn_t        iov;
         orte_rml_buffer_callback_fn_t buffer;
+        /* for the conduits (ofi) */
+        orte_rml_transport_callback_fn_t iov_transport;
+        orte_rml_buffer_transport_callback_fn_t buf_transport;
+   
     } cbfunc;
     void *cbdata;
 
@@ -153,6 +157,8 @@ typedef struct {
     opal_object_t super;
     opal_event_t ev;
     orte_rml_send_t send;
+    /* conduit_id */
+    uint8_t conduit_id;
 } orte_rml_send_request_t;
 OBJ_CLASS_DECLARATION(orte_rml_send_request_t);
 
@@ -305,6 +311,17 @@ ORTE_DECLSPEC int orte_rml_API_ft_event(int state);
 
 ORTE_DECLSPEC void orte_rml_API_purge(orte_process_name_t *peer);
 
+ORTE_DECLSPEC int orte_rml_API_query_transports(opal_value_t **providers);
+
+ORTE_DECLSPEC int orte_rml_API_send_transport_nb(int conduit_id,orte_process_name_t* peer, struct iovec* msg,
+                                       int count, orte_rml_tag_t tag,
+                                       orte_rml_callback_fn_t cbfunc, void* cbdata);
+ORTE_DECLSPEC int orte_rml_API_send_buffer_transport_nb(int conduit_id,
+                                              orte_process_name_t* peer,
+                                              struct opal_buffer_t* buffer,
+                                              orte_rml_tag_t tag,
+                                              orte_rml_buffer_callback_fn_t cbfunc,
+                                              void* cbdata);
 END_C_DECLS
 
 #endif /* MCA_RML_BASE_H */

--- a/orte/mca/rml/base/rml_base_frame.c
+++ b/orte/mca/rml/base/rml_base_frame.c
@@ -52,7 +52,10 @@ orte_rml_base_module_t orte_rml = {
     orte_rml_API_add_exception_handler,
     orte_rml_API_del_exception_handler,
     orte_rml_API_ft_event,
-    orte_rml_API_purge
+    orte_rml_API_purge,
+    orte_rml_API_query_transports,
+    orte_rml_API_send_transport_nb,
+    orte_rml_API_send_buffer_transport_nb
 };
 
 orte_rml_base_t orte_rml_base = {{{0}}};
@@ -173,12 +176,14 @@ int orte_rml_base_select(void)
 
        if (NULL == ((orte_rml_component_t *)component)->rml_init) {
            opal_output_verbose(10, orte_rml_base_framework.framework_output,
-                               "orte_rml_base_select: no init function; ignoring component [%s]",component->mca_component_name);
+                               "orte_rml_base_select: no init function; ignoring component [%s]",
+                               component->mca_component_name);
        } else {
            module = (mca_base_module_t *) ((orte_rml_component_t *)component)->rml_init(&priority);
            if (NULL == module) {
                opal_output_verbose(10, orte_rml_base_framework.framework_output,
-                                   "orte_rml_base_select: init returned failure [%s]",component->mca_component_name);
+                                   "orte_rml_base_select: init returned failure [%s]",
+                                   component->mca_component_name);
                continue;
            }
 
@@ -213,7 +218,7 @@ int orte_rml_base_select(void)
             opal_output(0, "\tComponent: %s Priority: %d", mod->component->mca_component_name, mod->pri);
         }
    }
-
+  
     return ORTE_SUCCESS;
 }
 

--- a/orte/mca/rml/base/rml_base_stubs.c
+++ b/orte/mca/rml/base/rml_base_stubs.c
@@ -43,9 +43,9 @@ int orte_rml_API_enable_comm(void)
     orte_rml_base_active_t *active, *next;
     int rc;
 
-    OPAL_OUTPUT_VERBOSE((1,orte_rml_base_framework.framework_output,
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
                          "%s rml:base:enable_comm",
-                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
 
     /* cycle thru the actives and let each one enable their comm */
     OPAL_LIST_FOREACH_SAFE(active, next, &orte_rml_base.actives, orte_rml_base_active_t) {
@@ -77,9 +77,9 @@ void orte_rml_API_finalize(void)
 {
     orte_rml_base_active_t *active;
 
-    OPAL_OUTPUT_VERBOSE((1,orte_rml_base_framework.framework_output,
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
                          "%s rml:base:finalize()",
-                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
 
     /* cycle thru the actives and see who can send it */
     OPAL_LIST_FOREACH(active, &orte_rml_base.actives, orte_rml_base_active_t) {
@@ -87,6 +87,10 @@ void orte_rml_API_finalize(void)
             active->module->finalize();
         }
     }
+
+    //moving here to avoid multiple calls from each plugin to this base fn
+    orte_rml_base_comm_stop();
+    
 }
 
 /** Get contact information for local process */
@@ -95,9 +99,9 @@ char* orte_rml_API_get_contact_info(void)
     char **rc = NULL, *tmp;
     orte_rml_base_active_t *active;
 
-    OPAL_OUTPUT_VERBOSE((1,orte_rml_base_framework.framework_output,
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
                          "%s rml:base:get_contact_info()",
-                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
 
     /* cycle thru the actives and see who can send it */
     OPAL_LIST_FOREACH(active, &orte_rml_base.actives, orte_rml_base_active_t) {
@@ -122,9 +126,9 @@ void orte_rml_API_set_contact_info(const char *contact_info)
 {
     orte_rml_base_active_t *active;
 
-    OPAL_OUTPUT_VERBOSE((1,orte_rml_base_framework.framework_output,
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
                          "%s rml:base:set_contact_info()",
-                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
 
     /* cycle thru the actives and let all modules parse the info
      * to extract their relevant portions */
@@ -142,9 +146,9 @@ int orte_rml_API_ping(const char* contact_info,
     int rc = ORTE_ERR_UNREACH;
     orte_rml_base_active_t *active;
 
-    OPAL_OUTPUT_VERBOSE((1,orte_rml_base_framework.framework_output,
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
                          "%s rml:base:ping()",
-                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
 
     /* cycle thru the actives and see if anyone can confirm connection */
     OPAL_LIST_FOREACH(active, &orte_rml_base.actives, orte_rml_base_active_t) {
@@ -170,10 +174,10 @@ int orte_rml_API_send_nb(orte_process_name_t* peer,
     int rc = ORTE_ERR_UNREACH;
     orte_rml_base_active_t *active;
 
-    OPAL_OUTPUT_VERBOSE((1,orte_rml_base_framework.framework_output,
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
                          "%s rml:base:send_nb() to peer %s",
                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                         ORTE_NAME_PRINT(peer)));
+                         ORTE_NAME_PRINT(peer));
 
     /* cycle thru the actives and see who can send it */
     OPAL_LIST_FOREACH(active, &orte_rml_base.actives, orte_rml_base_active_t) {
@@ -198,9 +202,9 @@ int orte_rml_API_send_buffer_nb(orte_process_name_t* peer,
     int rc = ORTE_ERR_UNREACH;
     orte_rml_base_active_t *active;
 
-    OPAL_OUTPUT_VERBOSE((1,orte_rml_base_framework.framework_output,
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
                          "%s rml:base:send_buffer_nb()",
-                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
 
     /* cycle thru the actives and see who can send it */
     OPAL_LIST_FOREACH(active, &orte_rml_base.actives, orte_rml_base_active_t) {
@@ -224,10 +228,10 @@ void orte_rml_API_recv_nb(orte_process_name_t* peer,
     orte_rml_base_active_t *active;
     orte_rml_recv_request_t *req;
 
-    OPAL_OUTPUT_VERBOSE((1, orte_rml_base_framework.framework_output,
+    opal_output_verbose(10, orte_rml_base_framework.framework_output,
                          "%s rml_recv_nb for peer %s tag %d",
                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                         ORTE_NAME_PRINT(peer), tag));
+                         ORTE_NAME_PRINT(peer), tag);
 
     /* cycle thru the actives and give each module a chance
      * to do whatever module-specific things they need to do */
@@ -263,10 +267,10 @@ void orte_rml_API_recv_buffer_nb(orte_process_name_t* peer,
     orte_rml_base_active_t *active;
     orte_rml_recv_request_t *req;
 
-    OPAL_OUTPUT_VERBOSE((1, orte_rml_base_framework.framework_output,
+    opal_output_verbose(10, orte_rml_base_framework.framework_output,
                          "%s rml_recv_buffer_nb for peer %s tag %d",
                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                         ORTE_NAME_PRINT(peer), tag));
+                         ORTE_NAME_PRINT(peer), tag);
 
     /* cycle thru the actives and give each module a chance
      * to do whatever module-specific things they need to do */
@@ -299,10 +303,10 @@ void orte_rml_API_recv_cancel(orte_process_name_t* peer, orte_rml_tag_t tag)
     orte_rml_base_active_t *active;
     orte_rml_recv_request_t *req;
 
-    OPAL_OUTPUT_VERBOSE((1, orte_rml_base_framework.framework_output,
+    opal_output_verbose(10, orte_rml_base_framework.framework_output,
                          "%s rml_recv_cancel for peer %s tag %d",
                          ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
-                         ORTE_NAME_PRINT(peer), tag));
+                         ORTE_NAME_PRINT(peer), tag);
 
     /* cycle thru the actives and give each module a chance
      * to do whatever module-specific things they need to do */
@@ -332,9 +336,9 @@ int orte_rml_API_add_exception_handler(orte_rml_exception_callback_t cbfunc)
     int rc = ORTE_ERROR;
     orte_rml_base_active_t *active;
 
-    OPAL_OUTPUT_VERBOSE((1,orte_rml_base_framework.framework_output,
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
                          "%s rml:base:add_exception_handler()",
-                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
 
     /* cycle thru the actives and see who can send it */
     OPAL_LIST_FOREACH(active, &orte_rml_base.actives, orte_rml_base_active_t) {
@@ -353,9 +357,9 @@ int orte_rml_API_del_exception_handler(orte_rml_exception_callback_t cbfunc)
     int rc = ORTE_ERROR;
     orte_rml_base_active_t *active;
 
-    OPAL_OUTPUT_VERBOSE((1,orte_rml_base_framework.framework_output,
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
                          "%s rml:base:del_exception_handler()",
-                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
 
     /* cycle thru the actives and see who can send it */
     OPAL_LIST_FOREACH(active, &orte_rml_base.actives, orte_rml_base_active_t) {
@@ -374,9 +378,9 @@ int orte_rml_API_ft_event(int state)
    int rc = ORTE_ERROR;
     orte_rml_base_active_t *active;
 
-    OPAL_OUTPUT_VERBOSE((1,orte_rml_base_framework.framework_output,
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
                          "%s rml:base:ft_event()",
-                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
 
     /* cycle thru the actives and let them all handle this event */
     OPAL_LIST_FOREACH(active, &orte_rml_base.actives, orte_rml_base_active_t) {
@@ -395,9 +399,9 @@ void orte_rml_API_purge(orte_process_name_t *peer)
 {
     orte_rml_base_active_t *active;
 
-    OPAL_OUTPUT_VERBOSE((1,orte_rml_base_framework.framework_output,
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
                          "%s rml:base:purge() - calling the respective plugin that implements this",
-                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME)));
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
 
     /* cycle thru the actives and let everyone purge related info */
     OPAL_LIST_FOREACH(active, &orte_rml_base.actives, orte_rml_base_active_t) {
@@ -406,3 +410,88 @@ void orte_rml_API_purge(orte_process_name_t *peer)
         }
     }
 }
+
+int orte_rml_API_query_transports(opal_value_t **providers)
+{
+
+    int rc = ORTE_ERROR;
+    orte_rml_base_active_t *active;
+
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                         "%s rml:base:orte_rml_API_query_transports()",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+
+    /* cycle thru the actives and let them all handle this event */
+    OPAL_LIST_FOREACH(active, &orte_rml_base.actives, orte_rml_base_active_t) {
+        if (NULL != active->module->query_transports) {
+            	  opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                                     "\n calling  module: %s->query_transports() \n",
+                                          active->component->mca_component_name);
+            if (ORTE_SUCCESS == (rc = active->module->query_transports(providers))) {
+                break;
+            }
+        }
+    }
+    return rc;
+
+}
+
+/** Send non-blocking iovec message through a specific transport */
+int orte_rml_API_send_transport_nb(int conduit_id,
+                         orte_process_name_t* peer,
+                         struct iovec* msg,
+                         int count,
+                         orte_rml_tag_t tag,
+                         orte_rml_callback_fn_t cbfunc,
+                         void* cbdata)
+{
+    int rc = ORTE_ERR_UNREACH;
+    orte_rml_base_active_t *active;
+
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                         "%s rml:base:send_transport_nb() to peer %s",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         ORTE_NAME_PRINT(peer));
+
+    /* cycle thru the actives and see who can send it */
+    OPAL_LIST_FOREACH(active, &orte_rml_base.actives, orte_rml_base_active_t) {
+        if (NULL != active->module->send_transport_nb) {
+            rc = active->module->send_transport_nb(conduit_id,peer, msg, count, tag, cbfunc, cbdata);
+            if (ORTE_SUCCESS == rc) {
+                /* someone was able to send it */
+                break;
+            }
+        }
+    }
+    return rc;
+}
+
+
+/** Send non-blocking buffer message through a specific transport */
+int orte_rml_API_send_buffer_transport_nb(int conduit_id,
+                                              orte_process_name_t* peer,
+                                              struct opal_buffer_t* buffer,
+                                              orte_rml_tag_t tag,
+                                              orte_rml_buffer_callback_fn_t cbfunc,
+                                              void* cbdata)
+{
+    int rc = ORTE_ERR_UNREACH;
+    orte_rml_base_active_t *active;
+
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                         "%s rml:base:send_buffer_transport_nb()",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+
+    /* cycle thru the actives and see who can send it */
+    OPAL_LIST_FOREACH(active, &orte_rml_base.actives, orte_rml_base_active_t) {
+        if (NULL != active->module->send_buffer_transport_nb) {
+            if (ORTE_SUCCESS == (rc = active->module->send_buffer_transport_nb(conduit_id,peer, buffer, tag, cbfunc, cbdata))) {
+                break;
+            }
+        }
+    }
+    return rc;
+}
+
+
+

--- a/orte/mca/rml/ofi/Makefile.am
+++ b/orte/mca/rml/ofi/Makefile.am
@@ -1,0 +1,54 @@
+#
+# Copyright (c) 2004-2005 The Trustees of Indiana University and Indiana
+#                         University Research and Technology
+#                         Corporation.  All rights reserved.
+# Copyright (c) 2004-2005 The University of Tennessee and The University
+#                         of Tennessee Research Foundation.  All rights
+#                         reserved.
+# Copyright (c) 2004-2009 High Performance Computing Center Stuttgart,
+#                         University of Stuttgart.  All rights reserved.
+# Copyright (c) 2004-2005 The Regents of the University of California.
+#                         All rights reserved.
+# Copyright (c) 2010      Cisco Systems, Inc.  All rights reserved.
+# Copyright (c) 2015      Intel, Inc. All rights reserved
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+sources = \
+	rml_ofi.h \
+	rml_ofi_request.h \
+	rml_ofi_component.c \
+	rml_ofi_send.c
+
+# Make the output library in this directory, and name it either
+# mca_<type>_<name>.la (for DSO builds) or libmca_<type>_<name>.la
+# (for static builds).
+
+if MCA_BUILD_orte_rml_ofi_DSO
+component_noinst =
+component_install = mca_rml_ofi.la
+else
+component_noinst = libmca_rml_ofi.la
+component_install =
+endif
+
+mcacomponentdir = $(ortelibdir)
+mcacomponent_LTLIBRARIES = $(component_install)
+mca_rml_ofi_la_SOURCES = $(sources)
+mca_rml_ofi_la_LDFLAGS = \
+			$(orte_rml_ofi_LDFLAGS) \
+			-module -avoid-version
+mca_rml_ofi_la_LIBADD = $(orte_rml_ofi_LIBS) \
+			$(OPAL_TOP_BUILDDIR)/opal/mca/common/libfabric/lib@OPAL_LIB_PREFIX@mca_common_libfabric.la
+
+noinst_LTLIBRARIES = $(component_noinst)
+libmca_rml_ofi_la_SOURCES = $(sources)
+libmca_rml_ofi_la_LDFLAGS = \
+		$(orte_rml_ofi_LDFLAGS) \
+		-module -avoid-version
+libmca_rml_ofi_la_LIBADD = $(orte_rml_ofi_LIBS)
+

--- a/orte/mca/rml/ofi/configure.m4
+++ b/orte/mca/rml/ofi/configure.m4
@@ -1,0 +1,29 @@
+# -*- shell-script -*-
+#
+# Copyright (c) 2013-2014 Intel, Inc. All rights reserved
+#
+# Copyright (c) 2014-2015 Cisco Systems, Inc.  All rights reserved.
+# $COPYRIGHT$
+#
+# Additional copyrights may follow
+#
+# $HEADER$
+#
+
+# MCA_orte_rml_ofi_POST_CONFIG(will_build)
+# ----------------------------------------
+# Only require the tag if we're actually going to be built
+
+# MCA_mtl_ofi_CONFIG([action-if-can-compile],
+#                    [action-if-cant-compile])
+# ------------------------------------------------
+AC_DEFUN([MCA_orte_rml_ofi_CONFIG],[
+    AC_CONFIG_FILES([orte/mca/rml/ofi/Makefile])
+
+    # ensure we already ran the common libfabric config
+    AC_REQUIRE([MCA_opal_common_libfabric_CONFIG])
+
+    AS_IF([test "$opal_common_libfabric_happy" = "yes"],
+          [$1],
+          [$2])
+])dnl

--- a/orte/mca/rml/ofi/rml_ofi.h
+++ b/orte/mca/rml/ofi/rml_ofi.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2015      Intel, Inc. All rights reserved
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef MCA_RML_OFI_RML_OFI_H
+#define MCA_RML_OFI_RML_OFI_H
+
+#include "orte_config.h"
+
+#include "opal/dss/dss_types.h"
+#include "opal/mca/event/event.h"
+#include "opal/mca/pmix/pmix.h"
+#include "orte/mca/rml/base/base.h"
+
+#include <rdma/fabric.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_tagged.h>
+
+#include "rml_ofi_request.h"
+
+//[A]
+/** the maximum open conduit - assuming system will have no more than 20 transports*/
+#define MAX_CONDUIT  20
+
+/** The OPAL key values  **/
+/* (char*)  ofi socket address (type IN) of the node process is running on */
+#define OPAL_RML_OFI_FI_SOCKADDR_IN                "rml.ofi.fisockaddrin"   
+/* (char*)  ofi socket address (type PSM) of the node process is running on */  
+#define OPAL_RML_OFI_FI_ADDR_PSMX                  "rml.ofi.fiaddrpsmx"       
+
+// MULTI_BUF_SIZE_FACTOR defines how large the multi recv buffer will be.
+// In order to use FI_MULTI_RECV feature efficiently, we need to have a 
+// large recv buffer so that we don't need to repost the buffer often to 
+// get the remaining data when the buffer is full
+#define MULTI_BUF_SIZE_FACTOR 8
+#define DEFAULT_MULTI_BUF_SIZE (1024 * 1024)
+
+
+#define CLOSE_FID(fd)			\
+	ret = 0;			\
+	do {				\
+		if ((fd)) {					\
+			ret = fi_close(&(fd)->fid);	\
+			fd = NULL;				\
+			if (ret)				\
+    		        {					\
+			    opal_output_verbose(10,orte_rml_base_framework.framework_output, 	\
+                                                " %s - fi_close failed with error- %d",		\
+                                                   ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),ret);	\
+		        }					\
+		}						\
+	} while (0);
+
+
+#define RML_OFI_RETRY_UNTIL_DONE(FUNC)         \
+    do {                                       \
+        do {                                   \
+            ret = FUNC;                        \
+            if(OPAL_LIKELY(0 == ret)) {break;} \
+        } while(-FI_EAGAIN == ret);            \
+    } while(0);
+
+BEGIN_C_DECLS
+
+
+/** This structure will hold the ep and all ofi objects for each transport
+and also the corresponding fi_info
+**/
+typedef struct {
+
+    /** conduit ID **/
+    uint8_t conduit_id;
+
+    /** fi_info for this transport */
+    struct fi_info *fabric_info;
+
+    /** Fabric Domain handle */
+    struct fid_fabric *fabric;
+
+    /** Access Domain handle */
+    struct fid_domain *domain;
+
+    /** Address vector handle */
+    struct fid_av *av;
+
+    /** Completion queue handle */
+    struct fid_cq *cq;
+
+    /** Endpoint to communicate on */
+    struct fid_ep *ep;
+
+    /** Endpoint name */
+    char ep_name[FI_NAME_MAX];
+
+    /** Endpoint name length */
+    size_t epnamelen;
+
+    /** OFI memory region */
+    struct fid_mr *mr_multi_recv;
+
+	/** buffer for tx and rx */
+    void *rxbuf;
+ 
+    uint64_t rxbuf_size;
+	
+	/* event,fd associated with the cq */ 
+	int fd;
+
+	/*event associated with progress fn */
+	opal_event_t progress_event;
+    bool progress_ev_active;
+
+} ofi_transport_conduit_t;
+
+
+typedef struct {
+    struct orte_rml_base_module_t super;
+
+    /** Fabric info structure of all supported transports in system **/
+    struct fi_info *fi_info_list;
+
+   /** OFI ep and corr fi_info for all the transports (conduit) **/
+    ofi_transport_conduit_t ofi_conduits[MAX_CONDUIT];
+
+    size_t min_ofi_recv_buf_sz;
+
+    /** "Any source" address */
+    fi_addr_t any_addr;
+
+    /** number of Conduits currently opened **/
+    uint8_t conduit_open_num;
+
+    opal_list_t              exceptions;
+    opal_list_t              queued_routing_messages;
+    opal_event_t            *timer_event;
+    struct timeval           timeout;
+	  
+} orte_rml_ofi_module_t;
+
+
+ORTE_MODULE_DECLSPEC extern orte_rml_component_t mca_rml_ofi_component;
+extern orte_rml_ofi_module_t orte_rml_ofi;
+
+int orte_rml_ofi_enable_comm(void);
+void orte_rml_ofi_fini(void);
+int orte_rml_ofi_ft_event(int state);
+int orte_rml_ofi_query_transports(opal_value_t **providers);
+int orte_rml_ofi_send_buffer_transport_nb(int conduit_id,
+                                              orte_process_name_t* peer,
+                                              struct opal_buffer_t* buffer,
+                                              orte_rml_tag_t tag,
+                                              orte_rml_buffer_callback_fn_t cbfunc,
+                                              void* cbdata);
+int orte_rml_ofi_send_transport_nb(int conduit_id,
+                                              orte_process_name_t* peer,
+                                              struct iovec* iov,
+                                              int count, 
+                                              orte_rml_tag_t tag,
+                                              orte_rml_callback_fn_t cbfunc,
+                                              void* cbdata);
+void free_conduit_resources( int conduit_id);
+void print_provider_list_info (struct fi_info *fi );
+
+
+int orte_rml_ofi_progress_no_inline(void);
+
+
+/** Send callback */
+int orte_rml_ofi_send_callback(struct fi_cq_data_entry *wc,
+                          orte_rml_ofi_request_t*);
+
+/** Error callback */
+int orte_rml_ofi_error_callback(struct fi_cq_err_entry *error,
+                           orte_rml_ofi_request_t*);
+
+/* OFI Recv handler */
+int orte_rml_ofi_recv_handler(struct fi_cq_data_entry *wc, uint8_t conduit_id);
+END_C_DECLS
+
+#endif
+

--- a/orte/mca/rml/ofi/rml_ofi_component.c
+++ b/orte/mca/rml/ofi/rml_ofi_component.c
@@ -1,0 +1,1039 @@
+/*
+ * Copyright (c) 2015 Intel, Inc. All rights reserved.
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "orte_config.h"
+#include "orte/constants.h"
+
+#include "opal/mca/base/base.h"
+#include "opal/util/output.h"
+#include "opal/mca/backtrace/backtrace.h"
+#include "opal/mca/event/event.h"
+
+#if OPAL_ENABLE_FT_CR == 1
+#include "orte/mca/rml/rml.h"
+#include "orte/mca/state/state.h"
+#endif
+#include "orte/mca/rml/base/base.h"
+#include "orte/mca/rml/rml_types.h"
+#include "orte/mca/routed/routed.h"
+#include "orte/mca/errmgr/errmgr.h"
+#include "orte/util/name_fns.h"
+#include "orte/runtime/orte_globals.h"
+
+#include "rml_ofi.h"
+
+static int my_priority=3;  
+static orte_rml_base_module_t* rml_ofi_component_init(int* priority);  
+static int rml_ofi_component_open(void);
+static int rml_ofi_component_close(void);
+
+
+/**
+ * component definition
+ */
+orte_rml_component_t mca_rml_ofi_component = {
+      /* First, the mca_base_component_t struct containing meta
+         information about the component itself */
+
+    .rml_version = {
+        ORTE_RML_BASE_VERSION_2_0_0,
+
+        .mca_component_name = "ofi",
+        MCA_BASE_MAKE_VERSION(component, ORTE_MAJOR_VERSION, ORTE_MINOR_VERSION,
+                              ORTE_RELEASE_VERSION),
+        .mca_open_component = rml_ofi_component_open,
+        .mca_close_component = rml_ofi_component_close,
+     },
+    .rml_data = {
+        /* The component is checkpoint ready */
+        MCA_BASE_METADATA_PARAM_CHECKPOINT
+    },
+    .rml_init = rml_ofi_component_init,
+};
+
+orte_rml_ofi_module_t orte_rml_ofi = {
+    {
+         .enable_comm = orte_rml_ofi_enable_comm,   //  [A] should we be calling this ?
+        .finalize = orte_rml_ofi_fini,
+        .query_transports = orte_rml_ofi_query_transports,
+        .send_transport_nb = orte_rml_ofi_send_transport_nb,
+        .send_buffer_transport_nb = orte_rml_ofi_send_buffer_transport_nb,
+
+    }
+};
+
+/* Local variables */
+static bool init_done = false;
+
+static int
+rml_ofi_component_open(void)
+{
+     /* Initialise endpoint and all queues */
+
+    orte_rml_ofi.fi_info_list = NULL;
+    orte_rml_ofi.min_ofi_recv_buf_sz = DEFAULT_MULTI_BUF_SIZE;
+
+    for( uint8_t conduit_id=0; conduit_id < MAX_CONDUIT ; conduit_id++) {
+        orte_rml_ofi.ofi_conduits[conduit_id].fabric =  NULL;
+        orte_rml_ofi.ofi_conduits[conduit_id].domain =  NULL;
+        orte_rml_ofi.ofi_conduits[conduit_id].av     =  NULL;
+        orte_rml_ofi.ofi_conduits[conduit_id].cq     =  NULL;
+        orte_rml_ofi.ofi_conduits[conduit_id].ep     =  NULL;
+        orte_rml_ofi.ofi_conduits[conduit_id].ep_name[0] = 0;
+        orte_rml_ofi.ofi_conduits[conduit_id].epnamelen = 0;
+        orte_rml_ofi.ofi_conduits[conduit_id].mr_multi_recv = NULL;
+        orte_rml_ofi.ofi_conduits[conduit_id].rxbuf = NULL;
+        orte_rml_ofi.ofi_conduits[conduit_id].rxbuf_size = 0;
+        orte_rml_ofi.ofi_conduits[conduit_id].progress_ev_active = false;
+    }
+
+    opal_output_verbose(1,orte_rml_base_framework.framework_output," from %s:%d rml_ofi_component_open()",__FILE__,__LINE__);
+
+    return ORTE_SUCCESS;
+}
+
+
+void free_conduit_resources( int conduit_id)
+{
+
+    int ret=0;
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                       " %s - free_conduit_resources() begin. conduit_id- %d",
+                       ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),conduit_id);
+    if (orte_rml_ofi.ofi_conduits[conduit_id].ep) {
+         CLOSE_FID(orte_rml_ofi.ofi_conduits[conduit_id].ep);
+         if (ret)
+         {
+            opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                                " %s - fi_close(ep) failed with error- %d",
+                                ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),ret);
+         }
+    }
+    if (orte_rml_ofi.ofi_conduits[conduit_id].mr_multi_recv) {
+         CLOSE_FID(orte_rml_ofi.ofi_conduits[conduit_id].mr_multi_recv);
+    }
+    if (orte_rml_ofi.ofi_conduits[conduit_id].cq) {
+         CLOSE_FID(orte_rml_ofi.ofi_conduits[conduit_id].cq);
+    }
+    if (orte_rml_ofi.ofi_conduits[conduit_id].av) {
+         CLOSE_FID(orte_rml_ofi.ofi_conduits[conduit_id].av);
+    }
+    if (orte_rml_ofi.ofi_conduits[conduit_id].domain) {
+         CLOSE_FID(orte_rml_ofi.ofi_conduits[conduit_id].domain);
+    }
+    if (orte_rml_ofi.ofi_conduits[conduit_id].fabric) {
+         fi_close((fid_t)orte_rml_ofi.ofi_conduits[conduit_id].fabric);      
+    }
+    if (orte_rml_ofi.ofi_conduits[conduit_id].rxbuf) {
+         free(orte_rml_ofi.ofi_conduits[conduit_id].rxbuf);
+    }
+
+    orte_rml_ofi.ofi_conduits[conduit_id].ep_name[0] = 0;
+    orte_rml_ofi.ofi_conduits[conduit_id].epnamelen = 0;
+    orte_rml_ofi.ofi_conduits[conduit_id].rxbuf = NULL;
+    orte_rml_ofi.ofi_conduits[conduit_id].rxbuf_size = 0;
+    orte_rml_ofi.ofi_conduits[conduit_id].fabric_info = NULL;
+
+    if( orte_rml_ofi.ofi_conduits[conduit_id].progress_ev_active) {
+        opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                            " %s - deleting progress event",
+                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+        opal_event_del( &orte_rml_ofi.ofi_conduits[conduit_id].progress_event);
+    }
+
+    return;
+}
+
+
+static int
+rml_ofi_component_close(void)
+{
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                            " %s - rml_ofi_component_close() -begin, total open conduits = %d",
+                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),orte_rml_ofi.conduit_open_num);
+
+    if(orte_rml_ofi.fi_info_list) {
+    (void) fi_freeinfo(orte_rml_ofi.fi_info_list);
+    }
+
+    /* Close endpoint and all queues */
+    for( uint8_t conduit_id=0;conduit_id<orte_rml_ofi.conduit_open_num;conduit_id++) {
+         free_conduit_resources(conduit_id);
+    }
+
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                        " %s - rml_ofi_component_close() end",ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+    return ORTE_SUCCESS;
+}
+
+
+void print_provider_list_info (struct fi_info *fi )
+{
+
+    
+    //Display all the details in the fi_info structure
+    struct fi_info *cur_fi = fi;
+    int fi_count = 0;
+
+    opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                        " %s - Print_provider_list_info() ", 
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+
+    while(cur_fi != NULL)   {
+        fi_count++;
+        opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                            " %d.\n",fi_count);
+        opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                            " fi_info[]->caps                  :  0x%x \n",cur_fi->caps);
+        opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                            " fi_info[]->mode                  :  0x%x \n",cur_fi->mode);
+        opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                            " fi_info[]->address_format        :  0x%x \n",cur_fi->addr_format);
+        opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                            " fi_info[]->fabric_attr->provname :  %s \n",cur_fi->fabric_attr->prov_name);
+        opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                            " fi_info[]->src_address           :  0x%x \n",cur_fi->src_addr);
+        opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                            " fi_info[]->dest_address          :  0x%x \n",cur_fi->dest_addr);
+        opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                            " EndPoint Attributes (ep_attr)    :");
+        switch( cur_fi->ep_attr->type)
+        {
+            case FI_EP_UNSPEC:      
+                 opal_output_verbose(10,orte_rml_base_framework.framework_output," FI_EP_UNSPEC \n");
+                 break;
+            case FI_EP_MSG:         
+                 opal_output_verbose(10,orte_rml_base_framework.framework_output," FI_EP_MSG \n");
+                 break;
+            case FI_EP_DGRAM:       
+                 opal_output_verbose(10,orte_rml_base_framework.framework_output," FI_EP_DGRAM \n");
+                 break;
+            case FI_EP_RDM:         
+                 opal_output_verbose(10,orte_rml_base_framework.framework_output," FI_EP_RDM \n");
+                 break;
+            default:                
+                 opal_output_verbose(10,orte_rml_base_framework.framework_output," %d",cur_fi->ep_attr->type);
+    }
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                        " Protocol            : 0x%x \n", cur_fi->ep_attr->protocol);
+    cur_fi = cur_fi->next;
+    }
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                        "Total # of providers supported is %d\n",fi_count);
+
+}
+
+/*
+ * This returns all the supported transports in the system that support endpoint type RDM (reliable datagram)
+ * The providers returned is a list of type opal_valut_t holding opal_list_t
+ */
+int orte_rml_ofi_query_transports(opal_value_t **providers)
+{
+    opal_list_t *ofi_prov = NULL;
+    opal_value_t *providers_list, *prev_provider=NULL, *next_provider=NULL;
+    struct fi_info *cur_fi = NULL;
+    int ret = 0, prov_num = 0;
+
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                        " %s -Begin of query_transports()",ORTE_NAME_PRINT(ORTE_PROC_MY_NAME) );
+    if ( NULL == *providers)
+    {
+        *providers = OBJ_NEW(opal_value_t);
+    }
+
+    providers_list = *providers;
+    
+    //Create the opal_value_t list in which each item is an opal_list_t that holds the provider details
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+      "Starting to add the providers in a loop from orte_rml_ofi.ofi_conduits[] %s:%d",__FILE__,__LINE__);
+   
+    for ( prov_num = 0; prov_num < orte_rml_ofi.conduit_open_num ; prov_num++ ) {
+        cur_fi = orte_rml_ofi.ofi_conduits[prov_num].fabric_info;
+        if( NULL != prev_provider)
+        {
+           //if there is another provider in the array, then add another item to the providers_list
+           next_provider = OBJ_NEW(opal_value_t);
+           providers_list->super.opal_list_next = &next_provider->super;   
+           providers_list->super.opal_list_prev = &prev_provider->super;
+           providers_list = (opal_value_t *)providers_list->super.opal_list_next;
+        }
+  
+        /*  populate the opal_list_t *ofi_prov with provider details from the 
+         *  orte_rml_ofi.fi_info_list array populated in the rml_ofi_component_init() fn.*/
+        ofi_prov = OBJ_NEW(opal_list_t);
+        opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                            "\n loading the attribute ORTE_CONDUIT_ID"); 
+        if( ORTE_SUCCESS != 
+                (ret = orte_set_attribute( ofi_prov, ORTE_CONDUIT_ID, ORTE_ATTR_GLOBAL,
+                       (void *)&orte_rml_ofi.ofi_conduits[prov_num].conduit_id ,OPAL_UINT8))) {
+            opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                                       "%s:%d Not able to add provider conduit_id ",__FILE__,__LINE__);
+                   return ORTE_ERROR;
+        }
+        opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                     "\n provider conduit_id : %d",orte_rml_ofi.ofi_conduits[prov_num].conduit_id);
+        opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                            "\n loading the attribute ORTE_PROV_NAME");
+        if( ORTE_SUCCESS == 
+            (ret = orte_set_attribute( ofi_prov, ORTE_PROV_NAME, ORTE_ATTR_GLOBAL,cur_fi->fabric_attr->prov_name ,OPAL_STRING))) {
+            opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                                "\n loading the attribute ORTE_PROTOCOL %s",fi_tostr(&cur_fi->ep_attr->protocol,FI_TYPE_PROTOCOL));
+            if( ORTE_SUCCESS == 
+                (ret = orte_set_attribute( ofi_prov, ORTE_PROTOCOL, ORTE_ATTR_GLOBAL,(void *)&cur_fi->ep_attr->protocol ,OPAL_UINT32))) {
+               // insert the opal_list_t into opal_value_t list
+               opal_value_load(providers_list,ofi_prov,OPAL_PTR);
+               opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                                  "\n loading the provider opal_list_t* prov=%x into opal_value_t list successful",
+                                  ofi_prov);
+            } else {
+                   opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                                       "%s:%d Not able to add provider name ",__FILE__,__LINE__);
+                   return ORTE_ERROR;
+            }
+        } else {
+               opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                                   "%s:%d Not able to add provider name ",__FILE__,__LINE__);
+               return ORTE_ERROR;
+        }
+
+        prev_provider = providers_list;
+        cur_fi = cur_fi->next;
+    }
+
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                        "\n%s:%d Completed Query Interface",__FILE__,__LINE__);
+    return ORTE_SUCCESS;
+}
+
+
+/*debug routine to print the opal_value_t returned by query interface */
+void print_transports_query()
+{
+    opal_value_t *providers=NULL;
+    char* prov_name = NULL;
+    int ret;
+    int32_t *protocol_ptr, protocol;
+    int8_t* prov_num;
+
+    protocol_ptr = &protocol;
+
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                        "\n print_transports_query() Begin- %s:%d",__FILE__,__LINE__);
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                        "\n calling the orte_rml_ofi_query_transports() ");
+    if( ORTE_SUCCESS == orte_rml_ofi_query_transports(&providers))
+    {
+        /*opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                "\n query_transports() completed, printing details\n"); */
+        while (providers)
+        {
+            //get the first opal_list_t;
+            opal_list_t *prov;
+            ret = opal_value_unload(providers,(void **)&prov,OPAL_PTR);
+            if (ret == OPAL_SUCCESS) {
+                /* opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                                   "\n %s:%d opal_value_unload() succeeded, opal_list* prov = %x",
+                                  __FILE__,__LINE__,prov); */
+                if( orte_get_attribute( prov, ORTE_CONDUIT_ID, (void **)&prov_num,OPAL_UINT8)) {
+                    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                                        "\n Provider conduit_id  : %d",*prov_num);
+                }
+                if( orte_get_attribute( prov, ORTE_PROTOCOL, (void **)&protocol_ptr,OPAL_UINT32)) {
+                    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                                        "\n Protocol  : %d", *protocol_ptr);  //fi_tostr(protocol_ptr,FI_TYPE_PROTOCOL));
+                }
+                if( orte_get_attribute( prov, ORTE_PROV_NAME, (void **)&prov_name ,OPAL_STRING)) {
+                    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                                        "\n Provider name : %s",prov_name);
+                } else {
+                    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                                    "\n Error in getting Provider name");
+                }
+            } else {
+                opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                                    "\n %s:%d opal_value_unload() failed, opal_list* prov = %x",
+                                   __FILE__,__LINE__,prov);
+            }
+            providers = (opal_value_t *)providers->super.opal_list_next;
+            /*  opal_output_verbose(1,orte_rml_base_framework.framework_output,"\n %s:%d 
+             * - Moving on to next provider provders=%x",__FILE__,__LINE__,providers);  
+            */
+        }
+    } else {
+        opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                            "\n query_transports() returned Error ");
+    }
+    opal_output_verbose(10,orte_rml_base_framework.framework_output,
+                        "\n End of print_transports_query() \n");
+}
+
+
+
+
+/**
+    conduit [in]: the conduit_id that triggered the progress fn
+ **/
+__opal_attribute_always_inline__ static inline int
+orte_rml_ofi_progress(ofi_transport_conduit_t* conduit)
+{
+    ssize_t ret;
+    int count=0;    /* number of messages read and processed */
+    struct fi_cq_data_entry wc = { 0 };
+    struct fi_cq_err_entry error = { 0 };
+    orte_rml_ofi_request_t *ofi_req;
+
+    opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s orte_rml_ofi_progress called for conduitid %d",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         conduit->conduit_id);
+    /**
+    * Read the work completions from the CQ.
+    * From the completion's op_context, we get the associated OFI request.
+    * Call the request's callback.
+    */
+    while (true) {
+        /* Read the cq - that triggered the libevent to call this progress fn. */
+        ret = fi_cq_read(conduit->cq, (void *)&wc, 1);
+        if (0 < ret) {
+            opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s cq read for conduitid %d - wc.flags = %x",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         conduit->conduit_id, wc.flags);
+            count++;
+            // check the flags to see if this is a send-completion or receive
+            if ( (wc.flags & FI_SEND) && (wc.flags & FI_TRANSMIT_COMPLETE) )
+            {
+                opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                       "%s Send completion received on conduitid %d",
+                       ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                       conduit->conduit_id);
+                if (NULL != wc.op_context) {
+                    /* get the context from the wc and call the message handler */
+                    ofi_req = TO_OFI_REQ(wc.op_context);
+                    assert(ofi_req);
+                    ret = orte_rml_ofi_send_callback(&wc, ofi_req);
+                    if (ORTE_SUCCESS != ret) {
+                        opal_output(orte_rml_base_framework.framework_output,
+                        "Error returned by OFI request event callback: %zd",
+                         ret);
+                         abort();
+                    }
+                    OBJ_RELEASE(ofi_req);
+                }
+            } else if ( (wc.flags & FI_RECV) && (wc.flags & FI_MULTI_RECV) ) {
+                    opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s Received message on conduitid %d - but buffer is consumed, need to repost",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         conduit->conduit_id);
+                        // call the receive message handler that will call the rml_base
+                        ret = orte_rml_ofi_recv_handler(&wc, conduit->conduit_id);
+                        // reposting buffer
+                        ret = fi_recv(orte_rml_ofi.ofi_conduits[conduit->conduit_id].ep,
+                          orte_rml_ofi.ofi_conduits[conduit->conduit_id].rxbuf,
+                          orte_rml_ofi.ofi_conduits[conduit->conduit_id].rxbuf_size,
+                          fi_mr_desc(orte_rml_ofi.ofi_conduits[conduit->conduit_id].mr_multi_recv),
+                          0,0);
+            } else if ( wc.flags & FI_RECV )  {
+                    opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s Received message on conduitid %d",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         conduit->conduit_id);
+                        // call the receive message handler that will call the rml_base
+                        ret = orte_rml_ofi_recv_handler(&wc, conduit->conduit_id);
+            } else if ( wc.flags & FI_MULTI_RECV ) {
+                    opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s Received buffer overrun message on conduitid %d - need to repost",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         conduit->conduit_id);
+                        // reposting buffer
+                        ret = fi_recv(orte_rml_ofi.ofi_conduits[conduit->conduit_id].ep,
+                          orte_rml_ofi.ofi_conduits[conduit->conduit_id].rxbuf,
+                          orte_rml_ofi.ofi_conduits[conduit->conduit_id].rxbuf_size,
+                          fi_mr_desc(orte_rml_ofi.ofi_conduits[conduit->conduit_id].mr_multi_recv),
+                          0,0);
+            }else {
+                opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                        "CQ has unhandled completion event with FLAG wc.flags = 0x%x",
+                         wc.flags);
+            }
+        } else if (ret == -FI_EAVAIL) {
+            /**
+            * An error occured and is being reported via the CQ.
+            * Read the error and forward it to the upper layer.
+            */
+            opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s cq_read for conduitid %d  returned error 0x%x <%s>",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         conduit->conduit_id, ret, 
+                         fi_strerror((int) -ret) );
+            ret = fi_cq_readerr(conduit->cq,
+                                &error,
+                                0);
+            if (0 > ret) {
+                opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                                "Error returned from fi_cq_readerr: %zd", ret);
+                abort();
+            }
+            assert(error.op_context);
+            /* get the context from wc and call the error handler */
+            ofi_req = TO_OFI_REQ(error.op_context);
+            assert(ofi_req);
+            ret = orte_rml_ofi_error_callback(&error, ofi_req);
+            if (ORTE_SUCCESS != ret) {
+               opal_output_verbose(1,orte_rml_base_framework.framework_output,
+               "Error returned by request error callback: %zd",
+               ret);
+               abort();
+            }
+        } else {
+            /**
+             * The CQ is empty. Return.
+             */
+            opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s Empty cq for conduitid %d,exiting from ofi_progress()",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         conduit->conduit_id );
+            break;
+        }
+    }
+    return count;
+}
+
+
+/*
+ * call the ofi_progress() fn to read the cq
+ *
+ */
+int cq_progress_handler(int sd, short flags, void *cbdata)
+{
+    ofi_transport_conduit_t* conduit = (ofi_transport_conduit_t*)cbdata;
+    int count;
+
+    opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s cq_progress_handler called for conduitid %d",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         conduit->conduit_id);
+
+      /* call the progress fn to read the cq and process the message
+        *    for the conduit */
+        count = orte_rml_ofi_progress(conduit);
+        return count;
+}
+
+
+static orte_rml_base_module_t*
+rml_ofi_component_init(int* priority)
+{
+    int ret, fi_version;
+    struct fi_info *hints, *fabric_info;
+    struct fi_cq_attr cq_attr = {0};
+    struct fi_av_attr av_attr = {0};
+    size_t namelen;
+    char   ep_name[FI_NAME_MAX]= {0};
+    uint8_t conduit_id = 0; //[A]
+
+    opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                        "%s - Entering rml_ofi_component_init()",ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+
+    /*[TODO] Limiting current implementation to APP PROCs.  The PMIX component does not get initialised for
+     *        ORTE_DAEMON_PROC so the OPAL_MODEX_SEND_STRING (opal_pmix.put) fails during initialisation, 
+     *        this needs to be fixed to support DAEMON PROC to use ofi
+    */
+    if (!ORTE_PROC_IS_APP) {
+        *priority = 0;
+        return NULL;
+    }
+
+    if (init_done) {
+        *priority = 2;
+        return &orte_rml_ofi.super;
+    }
+
+    *priority = 2;
+
+
+    /**
+     * Hints to filter providers
+     * See man fi_getinfo for a list of all filters
+     * mode:  Select capabilities MTL is prepared to support.
+     *        In this case, MTL will pass in context into communication calls
+     * ep_type:  reliable datagram operation
+     * caps:     Capabilities required from the provider.
+     *           Tag matching is specified to implement MPI semantics.
+     * msg_order: Guarantee that messages with same tag are ordered.
+     */
+
+    hints = fi_allocinfo();
+    if (!hints) {
+        opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                            "%s:%d: Could not allocate fi_info\n",
+                            __FILE__, __LINE__);
+        return NULL;
+    }
+
+    /**
+     * Refine filter for additional capabilities
+     * endpoint type : Reliable datagram
+     * threading:  Disable locking
+     * control_progress:  enable async progress
+     */
+     hints->mode               = FI_CONTEXT;
+     hints->ep_attr->type      = FI_EP_RDM;      /* Reliable datagram         */
+
+     hints->domain_attr->threading        = FI_THREAD_UNSPEC;
+     hints->domain_attr->control_progress = FI_PROGRESS_AUTO; 
+     hints->domain_attr->av_type          = FI_AV_MAP;
+
+    /**
+     * FI_VERSION provides binary backward and forward compatibility support
+     * Specify the version of OFI is coded to, the provider will select struct
+     * layouts that are compatible with this version.
+     */
+     fi_version = FI_VERSION(1, 0);
+
+    /**
+     * fi_getinfo:  returns information about fabric  services for reaching a
+     * remote node or service.  this does not necessarily allocate resources.
+     * Pass NULL for name/service because we want a list of providers supported.
+     */
+     ret = fi_getinfo(fi_version,    /* OFI version requested                    */
+                       NULL,          /* Optional name or fabric to resolve       */
+                       NULL,          /* Optional service name or port to request */
+                       0ULL,          /* Optional flag                            */
+                       hints,        /* In: Hints to filter providers            */
+                       &orte_rml_ofi.fi_info_list);   /* Out: List of matching providers          */
+     if (0 != ret) {
+        opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                            "%s:%d: fi_getinfo failed: %s\n",
+                            __FILE__, __LINE__, fi_strerror(-ret));
+    } else {
+
+        /* added for debug purpose - Print the provider info
+        print_transports_query();
+        print_provider_list_info(orte_rml_ofi.fi_info_list);
+        */
+
+        /** create the OFI objects for each transport in the system 
+        *   (fi_info_list) and store it in the ofi_conduits array **/
+        for( fabric_info = orte_rml_ofi.fi_info_list, conduit_id = 0; 
+                 NULL != fabric_info; fabric_info = fabric_info->next, conduit_id++)
+        {
+            orte_rml_ofi.ofi_conduits[conduit_id].conduit_id = conduit_id;
+            orte_rml_ofi.ofi_conduits[conduit_id].fabric_info = fabric_info;
+
+            // set FI_MULTI_RECV flag for all recv operations
+            fabric_info->rx_attr->op_flags = FI_MULTI_RECV;
+            /**
+            * Open fabric
+            * The getinfo struct returns a fabric attribute struct that can be used to
+            * instantiate the virtual or physical network. This opens a "fabric
+            * provider". See man fi_fabric for details.
+            */
+
+            ret = fi_fabric(fabric_info->fabric_attr,        /* In:  Fabric attributes             */
+                             &orte_rml_ofi.ofi_conduits[conduit_id].fabric,  /* Out: Fabric handle */
+                             NULL);                          /* Optional context for fabric events */
+            if (0 != ret) {
+                opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                                "%s:%d: fi_fabric failed: %s\n",
+                                __FILE__, __LINE__, fi_strerror(-ret));
+                    free_conduit_resources(conduit_id);
+                    /* abort this current transport, but check if next transport can be opened */
+                    continue;
+            }
+
+
+            /**
+            * Create the access domain, which is the physical or virtual network or
+            * hardware port/collection of ports.  Returns a domain object that can be
+            * used to create endpoints.  See man fi_domain for details.
+            */
+            ret = fi_domain(orte_rml_ofi.ofi_conduits[conduit_id].fabric,   /* In:  Fabric object */
+                             fabric_info,                                   /* In:  Provider          */
+                             &orte_rml_ofi.ofi_conduits[conduit_id].domain, /* Out: Domain oject  */
+                              NULL);                                        /* Optional context for domain events */
+            if (0 != ret) {
+                opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                                    "%s:%d: fi_domain failed: %s\n",
+                                    __FILE__, __LINE__, fi_strerror(-ret));
+                free_conduit_resources(conduit_id);
+                /* abort this current transport, but check if next transport can be opened */
+                continue;                               
+            }
+
+            /**
+            * Create a transport level communication endpoint.  To use the endpoint,
+            * it must be bound to completion counters or event queues and enabled,
+            * and the resources consumed by it, such as address vectors, counters,
+            * completion queues, etc.
+            * see man fi_endpoint for more details.
+            */
+            ret = fi_endpoint(orte_rml_ofi.ofi_conduits[conduit_id].domain, /* In:  Domain object   */
+                                fabric_info,                                /* In:  Provider        */
+                                &orte_rml_ofi.ofi_conduits[conduit_id].ep,  /* Out: Endpoint object */
+                              NULL);                                        /* Optional context     */
+            if (0 != ret) {
+                opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                                    "%s:%d: fi_endpoint failed: %s\n",
+                                    __FILE__, __LINE__, fi_strerror(-ret));
+                free_conduit_resources(conduit_id);
+                /* abort this current transport, but check if next transport can be opened */
+                continue;                               
+            }
+
+            /**
+            * Save the maximum inject size.
+            */
+             //orte_rml_ofi.max_inject_size = prov->tx_attr->inject_size;
+
+            /**
+            * Create the objects that will be bound to the endpoint.
+            * The objects include:
+            *     - completion queue for events
+            *     - address vector of other endpoint addresses
+            *     - dynamic memory-spanning memory region
+            */
+            cq_attr.format = FI_CQ_FORMAT_DATA;
+            ret = fi_cq_open(orte_rml_ofi.ofi_conduits[conduit_id].domain, 
+                             &cq_attr, &orte_rml_ofi.ofi_conduits[conduit_id].cq, NULL);
+            if (ret) {
+                opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                                "%s:%d: fi_cq_open failed: %s\n",
+                                __FILE__, __LINE__, fi_strerror(-ret));
+                free_conduit_resources(conduit_id);
+                /* abort this current transport, but check if next transport can be opened */
+                continue;                               
+            }
+
+            /**
+            * The remote fi_addr will be stored in the ofi_endpoint struct.
+            * So, we use the AV in "map" mode.
+            */
+            av_attr.type = FI_AV_MAP;
+            ret = fi_av_open(orte_rml_ofi.ofi_conduits[conduit_id].domain, 
+                             &av_attr, &orte_rml_ofi.ofi_conduits[conduit_id].av, NULL);
+            if (ret) {
+                opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                                    "%s:%d: fi_av_open failed: %s\n",
+                                    __FILE__, __LINE__, fi_strerror(-ret));
+                free_conduit_resources(conduit_id);
+                /* abort this current transport, but check if next transport can be opened */
+                continue;                               
+            }
+
+            /**
+            * Bind the CQ and AV to the endpoint object.
+            */
+            ret = fi_ep_bind(orte_rml_ofi.ofi_conduits[conduit_id].ep,
+                            (fid_t)orte_rml_ofi.ofi_conduits[conduit_id].cq,
+                            FI_SEND | FI_RECV);
+            if (0 != ret) {
+                opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                                    "%s:%d: fi_bind CQ-EP failed: %s\n",
+                                    __FILE__, __LINE__, fi_strerror(-ret));
+                free_conduit_resources(conduit_id);
+                /* abort this current transport, but check if next transport can be opened */
+                continue;                               
+            }
+
+            ret = fi_ep_bind(orte_rml_ofi.ofi_conduits[conduit_id].ep,
+                            (fid_t)orte_rml_ofi.ofi_conduits[conduit_id].av,
+                            0);
+            if (0 != ret) {
+                opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                                    "%s:%d: fi_bind AV-EP failed: %s\n",
+                                    __FILE__, __LINE__, fi_strerror(-ret));
+                free_conduit_resources(conduit_id);
+                /* abort this current transport, but check if next transport can be opened */
+                continue;                               
+            }
+
+            /**
+            * Enable the endpoint for communication
+            * This commits the bind operations.
+            */
+            ret = fi_enable(orte_rml_ofi.ofi_conduits[conduit_id].ep);
+            if (0 != ret) {
+                opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                                    "%s:%d: fi_enable failed: %s\n",
+                                    __FILE__, __LINE__, fi_strerror(-ret));
+                free_conduit_resources(conduit_id);
+                /* abort this current transport, but check if next transport can be opened */
+                continue;                               
+            }
+            opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                            "%s:%d ep enabled for conduit_id - %d ",__FILE__,__LINE__,conduit_id);
+
+
+            /**
+            * Get our address and publish it with modex.
+            **/
+            orte_rml_ofi.ofi_conduits[conduit_id].epnamelen = sizeof (orte_rml_ofi.ofi_conduits[conduit_id].ep_name);
+            ret = fi_getname((fid_t)orte_rml_ofi.ofi_conduits[conduit_id].ep,
+                            &orte_rml_ofi.ofi_conduits[conduit_id].ep_name[0],
+                            &orte_rml_ofi.ofi_conduits[conduit_id].epnamelen);
+            if (ret) {
+                        opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                                    "%s:%d: fi_getname failed: %s\n",
+                                    __FILE__, __LINE__, fi_strerror(-ret));
+                free_conduit_resources(conduit_id);
+                /* abort this current transport, but check if next transport can be opened */
+                  continue;
+            }
+             switch ( orte_rml_ofi.ofi_conduits[conduit_id].fabric_info->addr_format)
+            {
+                case  FI_SOCKADDR_IN :
+                    opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                            "%s:%d In FI_SOCKADDR_IN.  ",__FILE__,__LINE__);
+                    /*  Address is of type sockaddr_in (IPv4) */
+                    opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                            "%s sending Opal modex string for conduit_it %d, epnamelen = %d  ",
+                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),conduit_id,orte_rml_ofi.ofi_conduits[conduit_id].epnamelen);
+                    /*[debug] - print the sockaddr - port and s_addr */
+                    struct sockaddr_in* ep_sockaddr = (struct sockaddr_in*)orte_rml_ofi.ofi_conduits[conduit_id].ep_name;
+                    opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                            "%s port = 0x%x, InternetAddr = 0x%x  ",
+                            ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),ep_sockaddr->sin_port,ep_sockaddr->sin_addr.s_addr);
+                    /*[end debug]*/
+                    OPAL_MODEX_SEND_STRING( ret, OPAL_PMIX_GLOBAL,
+                                            OPAL_RML_OFI_FI_SOCKADDR_IN,
+                                            orte_rml_ofi.ofi_conduits[conduit_id].ep_name,
+                                            orte_rml_ofi.ofi_conduits[conduit_id].epnamelen);
+                    if (ORTE_SUCCESS != ret) {
+                        opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                                    "%s:%d: OPAL_MODEX_SEND failed: %s\n",
+                                    __FILE__, __LINE__, fi_strerror(-ret));
+                        free_conduit_resources(conduit_id);
+                        /*abort this current transport, but check if next transport can be opened*/
+                        continue;
+                    }
+                    break;
+                case  FI_ADDR_PSMX :
+                    opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                            "%s:%d In FI_ADDR_PSMX.  ",__FILE__,__LINE__);
+                    /*   Address is of type Intel proprietery PSMX */
+                     OPAL_MODEX_SEND_STRING( ret, OPAL_PMIX_GLOBAL,
+                                           OPAL_RML_OFI_FI_ADDR_PSMX,orte_rml_ofi.ofi_conduits[conduit_id].ep_name,
+                                                    orte_rml_ofi.ofi_conduits[conduit_id].epnamelen);
+                    if (ORTE_SUCCESS != ret) {
+                        opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                                "%s:%d: OPAL_MODEX_SEND failed: %s\n",
+                                 __FILE__, __LINE__, fi_strerror(-ret));
+                        free_conduit_resources(conduit_id);
+                        /*abort this current transport, but check if next transport can be opened*/
+                        continue;
+                    }
+                    break;
+                default:
+                     opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                     "%s:%d ERROR: Cannot register address, Unhandled addr_format - %d, ep_name - %s  ",
+                      __FILE__,__LINE__,orte_rml_ofi.ofi_conduits[conduit_id].fabric_info->addr_format,
+                      orte_rml_ofi.ofi_conduits[conduit_id].ep_name);
+            }
+
+            /**
+            * Set the ANY_SRC address.
+            */
+            orte_rml_ofi.any_addr = FI_ADDR_UNSPEC;
+
+            /**
+            *  Allocate tx,rx buffers and Post a multi-RECV buffer for each endpoint
+            **/
+            //[TODO later]  For now not considering ep_attr prefix_size (add this later)
+            orte_rml_ofi.ofi_conduits[conduit_id].rxbuf_size = DEFAULT_MULTI_BUF_SIZE * MULTI_BUF_SIZE_FACTOR;
+            orte_rml_ofi.ofi_conduits[conduit_id].rxbuf = malloc(orte_rml_ofi.ofi_conduits[conduit_id].rxbuf_size);
+
+            //[TODO] the context is used as NULL - this code needs to be added to provide the right context
+            ret = fi_mr_reg(orte_rml_ofi.ofi_conduits[conduit_id].domain,
+                            orte_rml_ofi.ofi_conduits[conduit_id].rxbuf,
+                            orte_rml_ofi.ofi_conduits[conduit_id].rxbuf_size,
+                            FI_RECV, 0, 0, 0, &orte_rml_ofi.ofi_conduits[conduit_id].mr_multi_recv, NULL);
+            ret = fi_setopt(&orte_rml_ofi.ofi_conduits[conduit_id].ep->fid, FI_OPT_ENDPOINT, FI_OPT_MIN_MULTI_RECV, 
+                            &orte_rml_ofi.min_ofi_recv_buf_sz, sizeof(orte_rml_ofi.min_ofi_recv_buf_sz) );
+     
+            ret = fi_recv(orte_rml_ofi.ofi_conduits[conduit_id].ep,
+                          orte_rml_ofi.ofi_conduits[conduit_id].rxbuf,
+                          orte_rml_ofi.ofi_conduits[conduit_id].rxbuf_size,
+                          fi_mr_desc(orte_rml_ofi.ofi_conduits[conduit_id].mr_multi_recv),
+                          0,0);  //[TODO] context param is 0, need to set it to right context var
+            /**
+            *  get the fd  and register the progress fn
+            **/
+            ret = fi_control(&orte_rml_ofi.ofi_conduits[conduit_id].cq->fid, FI_GETWAIT,
+                            (void *) &orte_rml_ofi.ofi_conduits[conduit_id].fd);
+            if (0 != ret) {
+                opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                                    "%s:%d: fi_control failed to get fd: %s\n",
+                                    __FILE__, __LINE__, fi_strerror(-ret));
+                free_conduit_resources(conduit_id);
+                /* abort this current transport, but check if next transport can be opened */
+                  continue;
+            }
+
+            /* - create the event  that will wait on the fd*/
+            // not a valid if if (!orte_rml_ofi.ofi_conduits[conduit_id].progress_ev_active) {
+            /* use the opal_event_set to do a libevent set on the fd
+            *  so when something is available to read, the cq_porgress_handler
+            *  will be called */
+            opal_event_set(orte_event_base,
+                       &orte_rml_ofi.ofi_conduits[conduit_id].progress_event,
+                       orte_rml_ofi.ofi_conduits[conduit_id].fd,
+                       OPAL_EV_READ|OPAL_EV_PERSIST,
+                       cq_progress_handler,
+                       &orte_rml_ofi.ofi_conduits[conduit_id]);
+            opal_event_add(&orte_rml_ofi.ofi_conduits[conduit_id].progress_event, 0);
+            orte_rml_ofi.ofi_conduits[conduit_id].progress_ev_active = true;
+           // }
+
+        } 
+
+    }
+
+    /** the number of conduits in the ofi_conduits[] array **/
+    orte_rml_ofi.conduit_open_num = conduit_id;
+
+    /**
+     * Free providers info since it's not needed anymore.
+    */
+    fi_freeinfo(hints);
+    hints = NULL;
+
+
+    /* only if atleast one conduit was successfully opened then return the module */
+    if (0 < conduit_id ) {
+        opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                    "%s:%d conduits openened=%d returning orte_rml_ofi.super",
+                    __FILE__,__LINE__,conduit_id);
+
+        OBJ_CONSTRUCT(&orte_rml_ofi.exceptions, opal_list_t);
+        init_done = true;
+        return &orte_rml_ofi.super;
+    } else {
+        opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                    "%s:%d Failed to open any conduits",__FILE__,__LINE__,conduit_id);
+        return NULL;
+    }
+
+}
+
+
+int
+orte_rml_ofi_enable_comm(void)
+{
+    int ret;
+
+    opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                        " %s - orte_rml_enable_comm() begin", 
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+    /* enable the base receive to get updates on contact info */
+    orte_rml_base_comm_start();
+    opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                        " %s - orte_rml_enable_comm() completed", 
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+
+    return ORTE_SUCCESS;
+}
+
+
+void
+orte_rml_ofi_fini(void)
+{
+    opal_list_item_t *item;
+    uint8_t conduit_id;
+
+
+    opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                        " %s -  orte_rml_ofi_fini() begin ", 
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+
+    while (NULL !=
+           (item = opal_list_remove_first(&orte_rml_ofi.exceptions))) {
+        OBJ_RELEASE(item);
+    }
+    OBJ_DESTRUCT(&orte_rml_ofi.exceptions);
+    opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                        " %s -  orte_rml_ofi_fini() completed ", 
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+}
+
+#if OPAL_ENABLE_FT_CR == 1
+int
+orte_rml_ofi_ft_event(int state) {
+    int exit_status = ORTE_SUCCESS;
+    int ret;
+
+
+    opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                        " %s -orte_rml_ofi_ft_event() start ", 
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+    if(OPAL_CRS_CHECKPOINT == state) {
+        ORTE_ACTIVATE_JOB_STATE(NULL, ORTE_JOB_STATE_FT_CHECKPOINT);
+    }
+    else if(OPAL_CRS_CONTINUE == state) {
+        ORTE_ACTIVATE_JOB_STATE(NULL, ORTE_JOB_STATE_FT_CONTINUE);
+    }
+    else if(OPAL_CRS_RESTART == state) {
+        ORTE_ACTIVATE_JOB_STATE(NULL, ORTE_JOB_STATE_FT_RESTART);
+    }
+    else if(OPAL_CRS_TERM == state ) {
+        ;
+    }
+    else {
+        ;
+    }
+
+
+    if(OPAL_CRS_CHECKPOINT == state) {
+        ;
+    }
+    else if(OPAL_CRS_CONTINUE == state) {
+        ;
+    }
+    else if(OPAL_CRS_RESTART == state) {
+        (void) mca_base_framework_close(&orte_ofi_base_framework);
+
+        if (ORTE_SUCCESS != (ret = mca_base_framework_open(&orte_ofi_base_framework, 0))) {
+            ORTE_ERROR_LOG(ret);
+            exit_status = ret;
+            goto cleanup;
+        }
+
+        if( ORTE_SUCCESS != (ret = orte_ofi_base_select())) {
+            ORTE_ERROR_LOG(ret);
+            exit_status = ret;
+            goto cleanup;
+        }
+    }
+    else if(OPAL_CRS_TERM == state ) {
+        ;
+    }
+    else {
+        ;
+    }
+
+ cleanup:
+     opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                         " %s -orte_rml_ofi_ft_event() end ", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+    return exit_status;
+}
+#else
+int
+orte_rml_ofi_ft_event(int state) {
+    opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                        " %s From orte_rml_ofi_ft_event() ", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+   return ORTE_SUCCESS;
+}
+#endif
+
+
+
+
+
+
+

--- a/orte/mca/rml/ofi/rml_ofi_request.h
+++ b/orte/mca/rml/ofi/rml_ofi_request.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2015      Intel, Inc. All rights reserved
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#ifndef ORTE_RML_OFI_REQUEST_H
+#define ORTE_RML_OFI_REQUEST_H
+
+
+#define TO_OFI_REQ(_ptr_ctx) \
+    container_of((_ptr_ctx), orte_rml_ofi_request_t, ctx)
+
+typedef enum {
+    ORTE_RML_OFI_SEND,
+    ORTE_RML_OFI_RECV,
+    ORTE_RML_OFI_ACK,
+    ORTE_RML_OFI_PROBE
+} orte_rml_ofi_request_type_t;
+
+
+struct orte_rml_ofi_msg_header_t{
+	opal_process_name_t	origin;  
+	opal_process_name_t	dst;
+	uint32_t			seq_num;
+	orte_rml_tag_t		tag;		
+};
+typedef struct orte_rml_ofi_msg_header_t orte_rml_ofi_msg_header_t;
+
+typedef struct {
+	opal_object_t super;
+    orte_rml_send_t *send;
+
+    /** OFI conduit_id the request will use - this is 
+    *	the reference to element into the orte_rml_ofi.ofi_conduits[] **/
+    uint8_t conduit_id;
+
+    /** OFI Request type */
+    orte_rml_ofi_request_type_t type;
+
+    /** OFI context */
+    struct fi_context ctx;
+
+    /** Completion count used by blocking and/or synchronous operations */
+    volatile int completion_count;
+    
+    /** Reference to the RML used to lookup */
+    /*  source of an ANY_SOURCE Recv        */
+    struct orte_rml_base_module_t* rml;
+
+	orte_rml_ofi_msg_header_t hdr;
+
+    /** Pack buffer */
+    void *data_blob;
+
+    /** Pack buffer size */
+    size_t length;
+
+  
+    /** Flag to prevent MPI_Cancel from cancelling a started Recv request */
+    volatile bool req_started;
+
+    /** Request's tag used in case of an error. */
+    uint64_t match_bits;
+
+    /** Remote OFI address used when a Recv needs to be ACKed */
+    fi_addr_t remote_addr;
+
+    /** Parent request which needs to be ACKed (e.g. Synchronous Send) */
+    struct orte_rml_ofi_request_t *parent;
+
+    /** Pointer to Mrecv request to complete */ 
+    struct mca_rml_request_t *mrecv_req;
+} orte_rml_ofi_request_t;
+OBJ_CLASS_DECLARATION(orte_rml_ofi_request_t);
+//typedef struct orte_rml_ofi_request_t orte_rml_ofi_request_t;
+
+#endif

--- a/orte/mca/rml/ofi/rml_ofi_send.c
+++ b/orte/mca/rml/ofi/rml_ofi_send.c
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2015      Intel, Inc. All rights reserved
+ * $COPYRIGHT$
+ *
+ * Additional copyrights may follow
+ *
+ * $HEADER$
+ */
+
+#include "orte_config.h"
+
+#include "opal/dss/dss_types.h"
+#include "opal/util/output.h"
+#include "opal/mca/event/event.h"
+
+#include "orte/mca/errmgr/errmgr.h"
+#include "orte/mca/rml/base/base.h"
+#include "orte/mca/rml/rml_types.h"
+
+#include <rdma/fabric.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_tagged.h>
+
+#include "rml_ofi.h"
+
+
+OBJ_CLASS_INSTANCE(orte_rml_ofi_request_t,
+                   opal_object_t,
+                   NULL, NULL);
+
+/** Send callback */
+/* [Desc] This is called from the progress fn when a send completion 
+** is received in the cq
+** wc [in] 	: the completion queue data entry
+** ofi_send_req [in]:  ofi send request with the send msg and callback
+*/
+int orte_rml_ofi_send_callback(struct fi_cq_data_entry *wc,
+                           orte_rml_ofi_request_t* ofi_req) 
+{
+    opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s orte_rml_ofi_send_callback called ",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME) );
+    assert(ofi_req->completion_count > 0);
+    ofi_req->completion_count--;
+    // call the callback fn of the sender
+	ofi_req->send->status = ORTE_SUCCESS;
+	ORTE_RML_SEND_COMPLETE(ofi_req->send);
+	// [TODO] need to check for error before returning success
+	return ORTE_SUCCESS;
+}
+
+/** Error callback */
+/* [Desc] This is called from the progress fn when a send completion 
+** is received in the cq
+** wc [in] 	: the completion queue data entry
+** ofi_send_req [in]:  ofi send request with the send msg and callback
+*/
+int orte_rml_ofi_error_callback(struct fi_cq_err_entry *error,
+                           orte_rml_ofi_request_t* ofi_req)
+{
+    opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s orte_rml_ofi_error_callback called ",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME) );
+	switch(error->err) {
+		default: 			
+			/* call the send-callback fn with error and return, also return failure status */
+			ofi_req->send->status = ORTE_ERR_CONDUIT_SEND_FAIL;     
+			ORTE_RML_SEND_COMPLETE(ofi_req->send);
+	}
+	return ORTE_SUCCESS;
+}
+
+/** Recv handler */
+/* [Desc] This is called from the progress fn when a recv completion 
+** is received in the cq
+** wc [in] 	: the completion queue data entry */
+int orte_rml_ofi_recv_handler(struct fi_cq_data_entry *wc, uint8_t conduit_id) 
+{
+	orte_rml_ofi_msg_header_t msg_hdr;
+	uint32_t msglen;
+	char *data;
+
+    opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s orte_rml_ofi_recv_handler called ",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME) );
+	/*copy the header and data from buffer and pass it on 
+	** since this is the conduit recv buffer don't want it to be released as
+	** considering re-using it, so for now copying to newly allocated *data 
+	** the *data will be released by orte_rml_base functions */
+	
+	memcpy(&msg_hdr,wc->buf,sizeof(orte_rml_ofi_msg_header_t));
+	msglen = wc->len - sizeof(orte_rml_ofi_msg_header_t);
+	data = (char *)malloc(msglen);
+	memcpy(data,(wc->buf+sizeof(orte_rml_ofi_msg_header_t)),msglen);
+
+	/* Since OFI is point-to-point, no need to check if the intended destination is me
+     send to RML */
+	ORTE_RML_POST_MESSAGE(&msg_hdr.origin, msg_hdr.tag, msg_hdr.seq_num,data,msglen);
+	
+}
+
+
+static void send_msg(int fd, short args, void *cbdata)
+{
+    orte_rml_send_request_t *req = (orte_rml_send_request_t*)cbdata;
+	orte_process_name_t *peer = &(req->send.dst);
+	orte_rml_tag_t tag = req->send.tag;
+	char *dest_ep_name;
+	size_t dest_ep_namelen = 0;
+	int ret = OPAL_ERROR;
+	fi_addr_t dest_fi_addr;
+	orte_rml_send_t *snd;
+	orte_rml_ofi_request_t* ofi_send_req = OBJ_NEW( orte_rml_ofi_request_t );
+	uint8_t conduit_id = req->conduit_id;
+   
+ 	snd = OBJ_NEW(orte_rml_send_t);
+    snd->dst = *peer;
+    snd->origin = *ORTE_PROC_MY_NAME;
+    snd->tag = tag;
+	if (NULL != req->send.iov) {
+        snd->iov = req->send.iov;
+        snd->count = req->send.count;
+        snd->cbfunc.iov = req->send.cbfunc.iov;
+    } else {
+        snd->buffer = req->send.buffer;
+        snd->cbfunc.buffer = req->send.cbfunc.buffer;
+    }
+    snd->cbdata = req->send.cbdata;
+
+    opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s send_msg_transport to peer %s at tag %d",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         ORTE_NAME_PRINT(peer), tag);
+
+	
+	/* get the peer address by doing modex_receive 	*/
+    opal_output_verbose(10, orte_rml_base_framework.framework_output,
+                         "%s calling OPAL_MODEX_RECV_STRING ", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME) );
+	OPAL_MODEX_RECV_STRING(ret, OPAL_RML_OFI_FI_SOCKADDR_IN, peer , (char **) &dest_ep_name, &dest_ep_namelen);
+    opal_output_verbose(10, orte_rml_base_framework.framework_output,
+                         "%s  Return value from OPAL_MODEX_RECV_STRING - %d, length returned - %d", 
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), ret, dest_ep_namelen);
+    /*print the sockaddr - port and s_addr */
+	struct sockaddr_in* ep_sockaddr = (struct sockaddr_in*) dest_ep_name;
+	opal_output_verbose(1,orte_rml_base_framework.framework_output,
+                       "%s obtained for peer %s port = 0x%x, InternetAddr = 0x%x  ",
+                        ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),ORTE_NAME_PRINT(peer),ep_sockaddr->sin_port,
+                        ep_sockaddr->sin_addr.s_addr);
+
+	if ( OPAL_SUCCESS == ret) {
+		opal_output_verbose(10, orte_rml_base_framework.framework_output,
+                         "%s OPAL_MODEX_RECV succeded, %s peer ep name obtained. length=%d",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         ORTE_NAME_PRINT(peer), dest_ep_namelen);
+		ret = fi_av_insert(orte_rml_ofi.ofi_conduits[conduit_id].av, dest_ep_name,1,&dest_fi_addr,0,NULL);
+		if( 0 > ret) {	
+			opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s fi_av_insert failed in send_msg()",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+			/* call the send-callback fn with error and return, also return failure status */
+			snd->status = ORTE_ERR_ADDRESSEE_UNKNOWN;
+			ORTE_RML_SEND_COMPLETE(snd);
+			snd = NULL;
+			//OBJ_RELEASE( ofi_send_req);
+		}
+		
+	} else {
+		
+		opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s OPAL_MODEX_RECV failed to obtain  %s peer ep name ",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         ORTE_NAME_PRINT(peer));
+			/* call the send-callback fn with error and return, also return failure status */
+			snd->status = ORTE_ERR_ADDRESSEE_UNKNOWN;
+			ORTE_RML_SEND_COMPLETE(snd);
+			snd = NULL;
+			//OBJ_RELEASE( ofi_send_req);
+	}
+	
+	ofi_send_req->send = snd;
+	ofi_send_req->completion_count = 1;
+
+	/* [DESC] we want to send the pid,seqnum,tag in addition to the data 
+	* 	copy all of this to header of message */
+	ofi_send_req->hdr.dst = ofi_send_req->send->dst;
+	ofi_send_req->hdr.origin = ofi_send_req->send->origin;
+	ofi_send_req->hdr.seq_num = ofi_send_req->send->seq_num;
+	ofi_send_req->hdr.tag	  = ofi_send_req->send->tag;
+
+	/* copy the header and the buffer/iov/data to the ofi_send_req->datablob and update ofi_send_req->length*/
+    ofi_send_req->length = sizeof(ofi_send_req->hdr);
+	if( NULL != ofi_send_req->send->buffer) {
+	     ofi_send_req->length += ofi_send_req->send->buffer->bytes_used;
+	 	 ofi_send_req->data_blob = (char *)malloc(ofi_send_req->length);
+	     memcpy( ofi_send_req->data_blob, &ofi_send_req->hdr, sizeof(ofi_send_req->hdr));
+    	 memcpy( (ofi_send_req->data_blob + sizeof(ofi_send_req->hdr) ), 
+		    	ofi_send_req->send->buffer->base_ptr, 
+			    ofi_send_req->send->buffer->bytes_used);
+    } else if ( NULL != ofi_send_req->send->iov) {
+		for (int i=0; i < ofi_send_req->send->count; i++) {
+		    ofi_send_req->length += ofi_send_req->send->iov[i].iov_len;
+        }
+        ofi_send_req->data_blob = (char *)malloc(ofi_send_req->length);
+        memcpy( ofi_send_req->data_blob, &ofi_send_req->hdr, sizeof(ofi_send_req->hdr));
+		int iovlen=0;
+        for (int i=0; i < ofi_send_req->send->count; i++) {
+            memcpy( (ofi_send_req->data_blob + sizeof(ofi_send_req->hdr)+ iovlen ), 
+		        	ofi_send_req->send->iov[i].iov_base, 
+			        ofi_send_req->send->iov[i].iov_len);
+			iovlen += ofi_send_req->send->iov[i].iov_len;
+        }
+    } else {
+        //just send the data
+        ofi_send_req->length += ofi_send_req->send->count;
+        ofi_send_req->data_blob = (char *)malloc(ofi_send_req->length);
+        memcpy( ofi_send_req->data_blob, &ofi_send_req->hdr, sizeof(ofi_send_req->hdr));
+    	memcpy( (ofi_send_req->data_blob + sizeof(ofi_send_req->hdr) ), 
+		    	ofi_send_req->send->data, 
+			    ofi_send_req->send->count);
+   }
+
+	/*  do the fi_send()  */
+	ofi_send_req->completion_count=1;
+	RML_OFI_RETRY_UNTIL_DONE(fi_send(orte_rml_ofi.ofi_conduits[conduit_id].ep,
+									 ofi_send_req->data_blob,
+									 ofi_send_req->length,
+							         fi_mr_desc(orte_rml_ofi.ofi_conduits[conduit_id].mr_multi_recv),
+									 dest_fi_addr,
+								     (void *)&ofi_send_req->ctx));
+
+
+    opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s End of send_msg_transport. fi_send completed to peer %s with tag %d",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         ORTE_NAME_PRINT(peer), tag);
+
+	// wait for completion to call the send callback fn (or) let progressfn handle this
+
+
+	free(dest_ep_name);
+    OBJ_RELEASE(req);
+}
+
+int orte_rml_ofi_send_transport_nb(int conduit_id,
+                                              orte_process_name_t* peer,
+                                              struct iovec* iov,
+                                              int count, 
+                                              orte_rml_tag_t tag,
+                                              orte_rml_callback_fn_t cbfunc,
+                                              void* cbdata)
+{
+    orte_rml_send_request_t *req;
+
+    opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s rml_ofi_send_transport to peer %s at tag %d",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         ORTE_NAME_PRINT(peer), tag);
+
+	
+	if( (0 > conduit_id) || ( conduit_id > orte_rml_ofi.conduit_open_num ) ) {
+		/* Invalid conduit ID provided */
+	    ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);
+        return ORTE_ERR_BAD_PARAM;	
+	}
+    if (ORTE_RML_TAG_INVALID == tag) {
+        /* cannot send to an invalid tag */
+        ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);
+        return ORTE_ERR_BAD_PARAM;
+    }
+    if (NULL == peer ||
+        OPAL_EQUAL == orte_util_compare_name_fields(ORTE_NS_CMP_ALL, ORTE_NAME_INVALID, peer)) {
+        /* cannot send to an invalid peer */
+        ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);
+        return ORTE_ERR_BAD_PARAM;
+    }
+    /* get ourselves into an event to protect against
+     * race conditions and threads
+     */
+	req = OBJ_NEW(orte_rml_send_request_t);   
+	req->conduit_id = conduit_id;
+    req->send.dst = *peer;
+    req->send.iov = iov;
+	req->send.count = count;
+    req->send.tag = tag;
+    req->send.cbfunc.iov = cbfunc;
+    req->send.cbdata = cbdata;
+
+    /* setup the event for the send callback */
+    opal_event_set(orte_event_base, &req->ev, -1, OPAL_EV_WRITE, send_msg, req);
+    opal_event_set_priority(&req->ev, ORTE_MSG_PRI);
+    opal_event_active(&req->ev, OPAL_EV_WRITE, 1);
+
+	return ORTE_SUCCESS;
+}
+
+
+int orte_rml_ofi_send_buffer_transport_nb(int conduit_id,
+                                              orte_process_name_t* peer,
+                                              struct opal_buffer_t* buffer,
+                                              orte_rml_tag_t tag,
+                                              orte_rml_buffer_transport_callback_fn_t cbfunc,
+                                              void* cbdata)
+{
+	orte_rml_send_request_t *req;
+
+    opal_output_verbose(1, orte_rml_base_framework.framework_output,
+                         "%s rml_ofi_send_buffer_transport to peer %s at tag %d",
+                         ORTE_NAME_PRINT(ORTE_PROC_MY_NAME),
+                         ORTE_NAME_PRINT(peer), tag);
+
+	
+	if( (0 > conduit_id) || ( conduit_id > orte_rml_ofi.conduit_open_num ) ) {
+		/* Invalid conduit ID provided */
+	    ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);
+        return ORTE_ERR_BAD_PARAM;	
+	}
+    if (ORTE_RML_TAG_INVALID == tag) {
+        /* cannot send to an invalid tag */
+        ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);
+        return ORTE_ERR_BAD_PARAM;
+    }
+    if (NULL == peer ||
+        OPAL_EQUAL == orte_util_compare_name_fields(ORTE_NS_CMP_ALL, ORTE_NAME_INVALID, peer)) {
+        /* cannot send to an invalid peer */
+        ORTE_ERROR_LOG(ORTE_ERR_BAD_PARAM);
+        return ORTE_ERR_BAD_PARAM;
+    }
+    /* get ourselves into an event to protect against
+     * race conditions and threads
+     */
+	req = OBJ_NEW(orte_rml_send_request_t);   
+	req->conduit_id = conduit_id;
+    req->send.dst = *peer;
+    req->send.buffer = buffer;
+    req->send.tag = tag;
+    req->send.cbfunc.buffer = cbfunc;
+    req->send.cbdata = cbdata;
+
+    /* setup the event for the send callback */
+    opal_event_set(orte_event_base, &req->ev, -1, OPAL_EV_WRITE, send_msg, req);
+    opal_event_set_priority(&req->ev, ORTE_MSG_PRI);
+    opal_event_active(&req->ev, OPAL_EV_WRITE, 1);
+
+	return ORTE_SUCCESS;
+}
+

--- a/orte/mca/rml/oob/rml_oob_component.c
+++ b/orte/mca/rml/oob/rml_oob_component.c
@@ -151,8 +151,8 @@ orte_rml_oob_fini(void)
     }
     OBJ_DESTRUCT(&orte_rml_oob_module.exceptions);
 
-    /* clear the base receive */
-    orte_rml_base_comm_stop();
+    /* clear the base receive - moved this to rml_stubs to handle all components
+    orte_rml_base_comm_stop(); */
 }
 
 #if OPAL_ENABLE_FT_CR == 1

--- a/orte/mca/rml/rml.h
+++ b/orte/mca/rml/rml.h
@@ -435,6 +435,139 @@ typedef int  (*orte_rml_module_ft_event_fn_t)(int state);
  */
 typedef void (*orte_rml_module_purge_fn_t)(orte_process_name_t *peer);
 
+/******** Interfaces for fabric libraries such as libfabric ****/
+
+/**
+ * Query the library to provide all the supported interfaces/transport
+ * providers in the current node/system.
+ *
+ * @param[out] providers  list of providers and their attributes.
+ *
+ * @retval ORTE_SUCCESS The providers list was populated successfully
+ * @retval ORTE_ERROR   An unspecified error occured
+*/
+typedef int (*orte_rml_module_query_transports_fn_t)(opal_value_t **providers);
+
+/**
+ * Send an iovec non-blocking message through a specific transport
+ *
+ * Send an array of iovecs to the specified peer.  The call
+ * will return immediately, although the iovecs may not be modified
+ * until the completion callback is triggered.  The iovecs *may* be
+ * passed to another call to send_nb before the completion callback is
+ * triggered.  The callback being triggered does not give any
+ * indication of remote completion.
+ *
+ * @param[in] peer   Name of receiving process
+ * @param[in] msg    Pointer to an array of iovecs to be sent
+ * @param[in] count  Number of iovecs in array
+ * @param[in] tag    User defined tag for matching send/recv
+ * @param[in] cbfunc Callback function on message comlpetion
+ * @param[in] cbdata User data to provide during completion callback
+ *
+ * @retval ORTE_SUCCESS The message was successfully started
+ * @retval ORTE_ERR_BAD_PARAM One of the parameters was invalid
+ * @retval ORTE_ERR_ADDRESSEE_UNKNOWN Contact information for the
+ *                    receiving process is not available
+ * @retval ORTE_ERROR  An unspecified error occurred
+ */
+typedef int (*orte_rml_module_send_transport_nb_fn_t)(int conduit_id,
+                                            orte_process_name_t* peer,
+                                            struct iovec* msg,
+                                            int count,
+                                            orte_rml_tag_t tag,
+                                            orte_rml_callback_fn_t cbfunc,
+                                            void* cbdata);
+/**
+ * Send a buffer non-blocking message through a specific transport
+ *
+ * Send a buffer to the specified peer.  The call
+ * will return immediately, although the buffer may not be modified
+ * until the completion callback is triggered.  The buffer *may* be
+ * passed to another call to send_nb before the completion callback is
+ * triggered.  The callback being triggered does not give any
+ * indication of remote completion.
+ *
+ * @param[in] conduit_id 
+ *                   The conduit_id associated with transport
+ *                   returned from orte_rml_module_query_transports_fn()
+ * @param[in] peer   Name of receiving process
+ * @param[in] buffer Pointer to buffer to be sent
+ * @param[in] tag    User defined tag for matching send/recv
+ * @param[in] cbfunc Callback function on message comlpetion
+ * @param[in] cbdata User data to provide during completion callback
+ *
+ * @retval ORTE_SUCCESS The message was successfully started
+ * @retval ORTE_ERR_BAD_PARAM One of the parameters was invalid
+ * @retval ORTE_ERR_ADDRESSEE_UNKNOWN Contact information for the
+ *                    receiving process is not available
+ * @retval ORTE_ERROR  An unspecified error occurred
+ */
+typedef int (*orte_rml_module_send_buffer_transport_nb_fn_t)(int conduit_id,
+                                                   orte_process_name_t* peer,
+                                                   struct opal_buffer_t* buffer,
+                                                   orte_rml_tag_t tag,
+                                                   orte_rml_buffer_callback_fn_t cbfunc,
+                                                   void* cbdata);
+
+
+/**
+ * Funtion prototype for callback from non-blocking iovec send and recv
+ *
+ * Funtion prototype for callback from non-blocking iovec send and recv.
+ * On send, the iovec pointer will be the same pointer passed to
+ * send_nb and count will equal the count given to send.
+ *
+ * On recv, the iovec pointer will be the address of a single iovec
+ * allocated and owned by the RML, not the process receiving the
+ * callback. Ownership of the data block can be transferred by setting
+ * a user variable to point to the data block, and setting the
+ * iovec->iov_base pointer to NULL.
+ *
+ * @note The parameter in/out parameters are relative to the user's callback
+ * function.
+ *
+ * @param[in] status  Completion status
+ * @param[in] peer    Opaque name of peer process
+ * @param[in] msg     Pointer to the array of iovec that was sent
+ *                    or to a single iovec that has been recvd
+ * @param[in] count   Number of iovecs in the array
+ * @param[in] tag     User defined tag for matching send/recv
+ * @param[in] cbdata  User data passed to send_nb()
+ */
+typedef void (*orte_rml_transport_callback_fn_t)(int status,
+                                       orte_process_name_t* peer,
+                                       struct iovec* msg,
+                                       int count,
+                                       orte_rml_tag_t tag,
+                                       void* cbdata);
+
+
+/**
+ * Funtion prototype for callback from non-blocking buffer send and receive
+ *
+ * Function prototype for callback from non-blocking buffer send and
+ * receive. On send, the buffer will be the same pointer passed to
+ * send_buffer_nb. On receive, the buffer will be allocated and owned
+ * by the RML, not the process receiving the callback.
+ *
+ * @note The parameter in/out parameters are relative to the user's callback
+ * function.
+ *
+ * @param[in] status  Completion status
+ * @param[in] peer    Name of peer process
+ * @param[in] buffer  Message buffer
+ * @param[in] tag     User defined tag for matching send/recv
+ * @param[in] cbdata  User data passed to send_buffer_nb() or recv_buffer_nb()
+ */
+typedef void (*orte_rml_buffer_transport_callback_fn_t)(int status,
+                                              orte_process_name_t* peer,
+                                              struct opal_buffer_t* buffer,
+                                              orte_rml_tag_t tag,
+                                              void* cbdata);
+
+
+
 /********* NEW RML QOS MESSAGING APIS *****************/
 /***** Questions *****/
 /*
@@ -606,6 +739,7 @@ struct orte_rml_base_module_t {
 
     /** Send non-blocking iovec message */
     orte_rml_module_send_nb_fn_t                 send_nb;
+
     /** Send non-blocking buffer message */
     orte_rml_module_send_buffer_nb_fn_t          send_buffer_nb;
 
@@ -628,6 +762,19 @@ struct orte_rml_base_module_t {
 
     /** Purge information */
     orte_rml_module_purge_fn_t                   purge;
+
+    /** Query information of transport in system */
+    orte_rml_module_query_transports_fn_t       query_transports;
+
+    /** Send non-blocking iovec message through a specific transport */
+    orte_rml_module_send_transport_nb_fn_t      send_transport_nb;
+
+    /** Send non-blocking buffer message */
+    orte_rml_module_send_buffer_transport_nb_fn_t  send_buffer_transport_nb;
+
+     
+   
+    
 };
 /** Convenience typedef */
 typedef struct orte_rml_base_module_t orte_rml_base_module_t;

--- a/orte/mca/rml/rml_types.h
+++ b/orte/mca/rml/rml_types.h
@@ -165,8 +165,19 @@ BEGIN_C_DECLS
 
 #define ORTE_RML_TAG_MAX                   100
 
+/*** RML OFI keys ***/
+#define ORTE_OFI_START_KEY  ORTE_QOS_MAX_KEY
+#define ORTE_PROV_NAME      (ORTE_OFI_START_KEY + 1)  	//char * - null terminated string containing provider name
+#define ORTE_PROTOCOL       (ORTE_OFI_START_KEY + 2)    //uint32 - protocol type as returned by fi_info
+#define ORTE_CONDUIT_ID     (ORTE_OFI_START_KEY + 3)    //uint8 - conduit_id for this transport         
+
 #define ORTE_RML_TAG_NTOH(t) ntohl(t)
 #define ORTE_RML_TAG_HTON(t) htonl(t)
+
+/*** length of the tag. change this when type of orte_rml_tag_t is changed ***/
+/*** max valu in unit32_t is 0xFFFF_FFFF when converted to char this is 8  **
+#define ORTE_RML_TAG_T_CHAR_LEN   8
+#define ORTE_RML_TAG_T_SPRINT	 "%8x" */
 
 /**
  * Message matching tag

--- a/orte/test/system/Makefile
+++ b/orte/test/system/Makefile
@@ -1,7 +1,7 @@
 PROGS = no_op sigusr_trap spin orte_nodename orte_spawn orte_loop_spawn orte_loop_child orte_abort get_limits \
         orte_tool orte_no_op binom oob_stress iof_stress iof_delay radix opal_interface orte_spin segfault \
         orte_exit test-time event-threads psm_keygen regex orte_errors evpri-test opal-evpri-test evpri-test2 \
-        mapper reducer opal_hotel orte_dfs ulfm
+        mapper reducer opal_hotel orte_dfs ulfm ofi_stress
 
 all: $(PROGS)
 
@@ -16,3 +16,6 @@ clean:
 
 oob_stress:
 	ortecc -o oob_stress oob_stress.c -lm
+
+ofi_stress:
+	ortecc -o ofi_stress ofi_stress.c -lm

--- a/orte/test/system/ofi_query_test.c
+++ b/orte/test/system/ofi_query_test.c
@@ -1,0 +1,140 @@
+#include "orte_config.h"
+
+#include <stdio.h>
+#include <signal.h>
+#include <math.h>
+
+#include <rdma/fabric.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fi_errno.h>
+#include <rdma/fi_tagged.h>
+
+#include "opal/runtime/opal_progress.h"
+
+#include "orte/util/proc_info.h"
+#include "orte/util/name_fns.h"
+#include "orte/runtime/orte_globals.h"
+#include "orte/mca/rml/rml.h"
+#include "orte/mca/rml/base/base.h"
+#include "orte/mca/rml/rml_types.h"
+#include "orte/mca/errmgr/errmgr.h"
+
+#include "orte/runtime/runtime.h"
+#include "orte/runtime/orte_wait.h"
+
+#define MY_TAG 12345
+#define MAX_COUNT 3
+
+static bool msg_recvd;
+static volatile bool msg_active;
+
+static void send_callback(int status, orte_process_name_t *peer,
+                          opal_buffer_t* buffer, orte_rml_tag_t tag,
+                          void* cbdata)
+
+{
+    OBJ_RELEASE(buffer);
+    if (ORTE_SUCCESS != status) {
+        exit(1);
+    }
+    msg_active = false;
+}
+
+
+//debug routine to print the opal_value_t returned by query interface
+void print_transports_query()
+{
+    opal_value_t *providers=NULL;
+    char* prov_name = NULL;
+    int ret;
+    int32_t *protocol_ptr, protocol;
+    int8_t conduit_id;
+    int8_t *prov_num=&conduit_id;
+    
+    protocol_ptr = &protocol;
+	
+    opal_output(0,"\n print_transports_query() Begin- %s:%d",__FILE__,__LINE__);
+    opal_output(0,"\n calling the orte_rml_ofi_query_transports() ");
+    if( ORTE_SUCCESS == orte_rml.query_transports(&providers))
+    {
+	opal_output(0,"\n query_transports() completed, printing details\n");
+	while (providers)
+	{
+
+		//get the first opal_list_t;
+        opal_list_t temp;
+		opal_list_t *prov = &temp;
+
+		ret = opal_value_unload(providers,(void **)&prov,OPAL_PTR);
+		if (ret == OPAL_SUCCESS) {
+    		    opal_output_verbose(1,orte_rml_base_framework.framework_output,"\n %s:%d opal_value_unload() succeeded, opal_list* prov = %x",
+                                                                                                                          __FILE__,__LINE__,prov); 
+            if( orte_get_attribute( prov, ORTE_CONDUIT_ID, (void **)&prov_num,OPAL_UINT8)) {
+                opal_output(0," Provider conduit_id  : %d",*prov_num);
+            }	
+		    if( orte_get_attribute( prov, ORTE_PROTOCOL, (void **)&protocol_ptr,OPAL_UINT32)) {
+		      	opal_output(0," Protocol  : %s",fi_tostr(protocol_ptr,FI_TYPE_PROTOCOL));
+		    }
+		    if( orte_get_attribute( prov, ORTE_PROV_NAME, (void **)&prov_name ,OPAL_STRING)) {
+		      	opal_output(0," Provider name : %s",prov_name);
+		    } else {
+			opal_output(0," Error in getting Provider name");
+		    }
+		} else {
+    		    opal_output(0," %s:%d opal_value_unload() failed, opal_list* prov = %x",__FILE__,__LINE__,prov); 	
+		}
+		providers = (opal_value_t *)providers->super.opal_list_next;
+    	//	opal_output_verbose(1,orte_rml_base_framework.framework_output,"\n %s:%d - 
+        //                                Moving on to next provider provders=%x",__FILE__,__LINE__,providers);
+	}
+    } else {
+        opal_output(0,"\n query_transports() returned Error ");
+    }
+    opal_output(0,"\n End of print_transports_query() from ofi_query_test.c \n");
+
+  //need to free all the providers here
+}
+
+
+int
+main(int argc, char *argv[]){
+    int count;
+    int msgsize;
+    uint8_t *msg;
+    int i, j, rc;
+    orte_process_name_t peer;
+    double maxpower;
+    opal_buffer_t *buf;
+    orte_rml_recv_cb_t blob;
+
+    
+     opal_output(0, "%s pid = %d ", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), getpid());
+
+     /*
+     * Init
+     */
+    orte_init(&argc, &argv, ORTE_PROC_NON_MPI);
+   //  orte_init(&argc, &argv, ORTE_PROC_MPI);
+
+        /*
+     * Runtime Messaging Layer  - added this as RML was not being initialised in the app process, 
+     * but now ompimaster has code added to call this automatically
+     */
+/*
+     if (ORTE_SUCCESS == ( mca_base_framework_open(&orte_rml_base_framework, 0))) {
+	 opal_output(0, "%s RML framework opened successfully ", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), getpid());
+	if (ORTE_SUCCESS == orte_rml_base_select()) {
+	    opal_output(0, "%s RML framework base_select completed successfully ", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), getpid());
+	    print_transports_query();
+	}
+    }
+*/
+
+    print_transports_query();
+    opal_output(0, "%s calling orte_finalize() from ofi_query_test.c ",ORTE_NAME_PRINT(ORTE_PROC_MY_NAME));
+    orte_finalize();
+
+    return 0;
+}

--- a/orte/test/system/ofi_stress.c
+++ b/orte/test/system/ofi_stress.c
@@ -1,0 +1,117 @@
+#include "orte_config.h"
+
+#include <stdio.h>
+#include <signal.h>
+#include <math.h>
+
+#include "opal/runtime/opal_progress.h"
+
+#include "orte/util/proc_info.h"
+#include "orte/util/name_fns.h"
+#include "orte/runtime/orte_globals.h"
+#include "orte/mca/rml/rml.h"
+#include "orte/mca/errmgr/errmgr.h"
+
+#include "orte/runtime/runtime.h"
+#include "orte/runtime/orte_wait.h"
+
+#define MY_TAG 12345
+#define MAX_COUNT 3
+
+static bool msg_recvd;
+static volatile bool msg_active;
+
+static void send_callback(int status, orte_process_name_t *peer,
+                          opal_buffer_t* buffer, orte_rml_tag_t tag,
+                          void* cbdata)
+
+{
+    OBJ_RELEASE(buffer);
+    if (ORTE_SUCCESS != status) {
+        exit(1);
+    }
+    msg_active = false;
+}
+
+
+int
+main(int argc, char *argv[]){
+    int count;
+    int msgsize;
+    uint8_t *msg;
+    int i, j, rc;
+    orte_process_name_t peer;
+    double maxpower;
+    opal_buffer_t *buf;
+    orte_rml_recv_cb_t blob;
+    int sock_conduit_id = 0;  //use the ethernet
+
+    /*
+     * Init
+     */
+    orte_init(&argc, &argv, ORTE_PROC_NON_MPI);
+
+    if (argc > 1) {
+        count = atoi(argv[1]);
+        if (count < 0) {
+            count = INT_MAX-1;
+        }
+    } else {
+        count = MAX_COUNT;
+    }
+
+    peer.jobid = ORTE_PROC_MY_NAME->jobid;
+    peer.vpid = ORTE_PROC_MY_NAME->vpid + 1;
+    if (peer.vpid == orte_process_info.num_procs) {
+        peer.vpid = 0;
+    }
+
+    for (j=1; j < count+1; j++) {
+        /* rank0 starts ring */
+        if (ORTE_PROC_MY_NAME->vpid == 0) {
+            /* setup the initiating buffer - put random sized message in it */
+            buf = OBJ_NEW(opal_buffer_t);
+
+            maxpower = (double)(j%7);
+            msgsize = (int)pow(10.0, maxpower);
+            opal_output(0, "Ring %d message size %d bytes", j, msgsize);
+            msg = (uint8_t*)malloc(msgsize);
+            opal_dss.pack(buf, msg, msgsize, OPAL_BYTE);
+            free(msg);
+            orte_rml.send_buffer_transport_nb(sock_conduit_id,&peer, buf, MY_TAG, orte_rml_send_callback, NULL);
+
+            /* wait for it to come around */
+            OBJ_CONSTRUCT(&blob, orte_rml_recv_cb_t);
+            blob.active = true;
+            orte_rml.recv_buffer_nb(ORTE_NAME_WILDCARD, MY_TAG,
+                                    ORTE_RML_NON_PERSISTENT,
+                                    orte_rml_recv_callback, &blob);
+            ORTE_WAIT_FOR_COMPLETION(blob.active);
+            OBJ_DESTRUCT(&blob);
+
+            opal_output(0, "%s Ring %d completed", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), j);
+        } else {
+            /* wait for msg */
+            OBJ_CONSTRUCT(&blob, orte_rml_recv_cb_t);
+            blob.active = true;
+            orte_rml.recv_buffer_nb(ORTE_NAME_WILDCARD, MY_TAG,
+                                    ORTE_RML_NON_PERSISTENT,
+                                    orte_rml_recv_callback, &blob);
+            ORTE_WAIT_FOR_COMPLETION(blob.active);
+
+            opal_output(0, "%s received message %d from %s", ORTE_NAME_PRINT(ORTE_PROC_MY_NAME), j, ORTE_NAME_PRINT(&blob.name));
+
+            /* send it along */
+            buf = OBJ_NEW(opal_buffer_t);
+            opal_dss.copy_payload(buf, &blob.data);
+            OBJ_DESTRUCT(&blob);
+            msg_active = true;
+            orte_rml.send_buffer_transport_nb(sock_conduit_id,&peer, buf, MY_TAG, send_callback, NULL);
+            ORTE_WAIT_FOR_COMPLETION(msg_active);
+        }
+    }
+
+    orte_finalize();
+
+    return 0;
+}

--- a/orte/util/error_strings.c
+++ b/orte/util/error_strings.c
@@ -234,6 +234,9 @@ int orte_err2str(int errnum, const char **errmsg)
     case ORTE_ERR_JOB_CANCELLED:
         retval = "Job cancelled";
         break;
+    case ORTE_ERR_CONDUIT_SEND_FAIL:
+        retval = " Transport Conduit returned send error";
+        break;
     default:
         if (orte_report_silent_errors) {
             retval = "Unknown error";


### PR DESCRIPTION
uses the hardware fabric for communication.
Currently the OFI plugin has been tested to work with
ethernet fabric.
The following new interfaces are added to rml ->
query_transports -  Returns as an opal_list all the supported fabric transport
		    For each transport the below is returned.
		    The conduit_id starts from 0.
		    1.the conduit_id corresponding to the transport,
                    2.Provider name (fabric)
		    3.Protocol
send_transport_nb - Same as send_nb, but takes additional parameter conduit_id
                    to specify the transport to be used.

send_buffer_transport_nb - Same as send_buffer_nb, but takes additional parameter conduit_id
                    to specify the transport to be used.
This is still WIP, and below items need to be addressed ->
1.	Enable Modex_send/recv for daemons.  Currently it is verified working for app processes only.  
2.	On recv the OFI recv_handler() is calling the ORTE_RML_POST_MESSAGE that calls the orte_rml_base_complete_recv_msg()
The orte_rml_base_complete_recv_msg() need to be modified to provide the conduit_id as part of the registered recv callback fn.
3.	Handling of fragmenting big messages so the OFI recv_buffer can be made small (and can handle any message size)
4.	Error handling when send or recv fails   (this is missing in a few cases)
5.    conduit_id starts from 0, this needs to be changed to 1


	modified:   ../.gitignore
	modified:   ../orte/include/orte/constants.h
	modified:   ../orte/mca/ess/base/ess_base_std_orted.c
	modified:   ../orte/mca/ess/pmi/ess_pmi_module.c
	modified:   ../orte/mca/rml/base/base.h
	modified:   ../orte/mca/rml/base/rml_base_frame.c
	modified:   ../orte/mca/rml/base/rml_base_stubs.c
	new file:   ../orte/mca/rml/ofi/Makefile.am
	new file:   ../orte/mca/rml/ofi/configure.m4
	new file:   ../orte/mca/rml/ofi/rml_ofi.h
	new file:   ../orte/mca/rml/ofi/rml_ofi_component.c
	new file:   ../orte/mca/rml/ofi/rml_ofi_request.h
	new file:   ../orte/mca/rml/ofi/rml_ofi_send.c
	modified:   ../orte/mca/rml/oob/rml_oob_component.c
	modified:   ../orte/mca/rml/rml.h
	modified:   ../orte/mca/rml/rml_types.h
	modified:   ../orte/test/system/Makefile
	new file:   ../orte/test/system/ofi_query_test.c
	new file:   ../orte/test/system/ofi_stress.c
	modified:   ../orte/util/error_strings.c